### PR TITLE
fix: format numbers greater than 9,999,999 correctly

### DIFF
--- a/src/main/java/com/toofifty/easyblastfurnace/utils/RSNumberFormat.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/RSNumberFormat.java
@@ -12,7 +12,7 @@ public class RSNumberFormat
             return String.format("%,dK", number / 1000);
         }
 
-        return String.format("%,dM", number / 1000);
+        return String.format("%,dM", number / 1000000);
     }
 
     public static String format(double number)


### PR DESCRIPTION
This pull request fixes a bug in the code responsible for formatting numbers for the statistics overlay. For example, one would expect the number 14,000,000 to be displayed as “14M”, but due to the bug the most recent release displays the number as “14,000M” instead.