### PR TITLE
Smithing Cape checks and extra config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Helps you train at the blast furnace more efficiently
 ## Requirements
 
 - Ice gloves or Smiths Gloves (i)
-- Goldsmith gauntlets (for gold bar & hybrid methods)
+- Goldsmith gauntlets or Smithing cape (for gold bar & hybrid methods)
 - Coal bag (for metal bar & hybrid methods)
 - Stamina potions easily accessible in bank
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.8.32'
+def runeLiteVersion = '1.8.32.2'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.8.31'
+def runeLiteVersion = '1.8.32'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.8.25'
+def runeLiteVersion = '1.8.31'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnaceConfig.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnaceConfig.java
@@ -277,4 +277,26 @@ public interface EasyBlastFurnaceConfig extends Config
     {
         return 50;
     }
+
+    @ConfigItem(
+        position = 5,
+        keyName = "ignoreRemainingPotion",
+        name = "Ignore remaining stamina potion",
+        description = "Ignore the remaining stamina potion timer if the Low energy threshold has been reached."
+    )
+    default boolean ignoreRemainingPotion()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+        position = 6,
+        keyName = "addCoalBuffer",
+        name = "Add coal buffer",
+        description = "Ensure there is always more coal than needed in the furnace. This avoids stalls while bars are created."
+    )
+    default boolean addCoalBuffer()
+    {
+        return false;
+    }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
@@ -35,7 +35,7 @@ public class EasyBlastFurnacePlugin extends Plugin
 
     public static final WorldPoint PICKUP_POSITION = new WorldPoint(1940, 4962, 0);
 
-    private static final Pattern COAL_FULL_MESSAGE = Pattern.compile("^The coal bag contains 27 pieces of coal.$");
+    private static final Pattern COAL_FULL_MESSAGE = Pattern.compile("^The coal bag is full.$");
     private static final Pattern COAL_EMPTY_MESSAGE = Pattern.compile("^The coal bag is now empty.$");
 
     private static final String FILL_ACTION = "Fill";

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/DrinkStaminaMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/DrinkStaminaMethod.java
@@ -23,7 +23,7 @@ public class DrinkStaminaMethod extends Method
     public MethodStep next(BlastFurnaceState state)
     {
         if (!state.getPlayer().needsStamina() &&
-            (state.getInventory().has(new int[]{ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3}))) {
+            (state.getInventory().has(ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3))) {
             return depositInventory;
         }
 
@@ -33,35 +33,35 @@ public class DrinkStaminaMethod extends Method
             return depositInventory;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.STAMINA_POTION1})) {
+        if (state.getInventory().has(ItemID.STAMINA_POTION1)) {
             return drinkStaminaPotion1;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.STAMINA_POTION2})) {
+        if (state.getInventory().has(ItemID.STAMINA_POTION2)) {
             return drinkStaminaPotion2;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.STAMINA_POTION3})) {
+        if (state.getInventory().has(ItemID.STAMINA_POTION3)) {
             return drinkStaminaPotion3;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.STAMINA_POTION4})) {
+        if (state.getInventory().has(ItemID.STAMINA_POTION4)) {
             return drinkStaminaPotion4;
         }
 
-        if (state.getBank().has(new int[]{ItemID.STAMINA_POTION1})) {
+        if (state.getBank().has(ItemID.STAMINA_POTION1)) {
             return withdrawStaminaPotion1;
         }
 
-        if (state.getBank().has(new int[]{ItemID.STAMINA_POTION2})) {
+        if (state.getBank().has(ItemID.STAMINA_POTION2)) {
             return withdrawStaminaPotion2;
         }
 
-        if (state.getBank().has(new int[]{ItemID.STAMINA_POTION3})) {
+        if (state.getBank().has(ItemID.STAMINA_POTION3)) {
             return withdrawStaminaPotion3;
         }
 
-        if (state.getBank().has(new int[]{ItemID.STAMINA_POTION4})) {
+        if (state.getBank().has(ItemID.STAMINA_POTION4)) {
             return withdrawStaminaPotion4;
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -18,7 +18,11 @@ public class GoldBarMethod extends Method
         }
 
         if (!state.getInventory().has(ItemID.GOLDSMITH_GAUNTLETS) &&
-            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS)) {
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPE) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawGoldsmithGauntlets : openBank;
         }
 
@@ -32,7 +36,9 @@ public class GoldBarMethod extends Method
         if (prerequisite != null) return prerequisite;
 
         if (state.getInventory().has(ItemID.GOLD_ORE)) {
-            if (!state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS)) {
+            if (!state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS) &&
+                !state.getEquipment().equipped(ItemID.SMITHING_CAPE) &&
+                !state.getEquipment().equipped(ItemID.SMITHING_CAPET)) {
                 return equipGoldsmithGauntlets;
             }
             return putOntoConveyorBelt;

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -10,19 +10,24 @@ public class GoldBarMethod extends Method
     {
         // ensure player has both ice gloves & goldsmith gauntlets either in inventory or equipped
 
-        if (state.getInventory().has(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (state.getInventory().has(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) &&
+            !state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
             return state.getBank().isOpen() ? withdrawIceOrSmithsGloves : openBank;
         }
 
-        if (state.getBank().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getInventory().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (state.getBank().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawSmithingCape : openBank;
         }
 
-        if (!state.getInventory().has(new int[]{ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (state.getInventory().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
+            return equipSmithingCape;
+        }
+
+        if (!state.getInventory().has(ItemID.GOLDSMITH_GAUNTLETS) &&
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawGoldsmithGauntlets : openBank;
         }
 
@@ -35,14 +40,9 @@ public class GoldBarMethod extends Method
         MethodStep prerequisite = checkPrerequisite(state);
         if (prerequisite != null) return prerequisite;
 
-        if (state.getInventory().has(new int[]{ItemID.GOLD_ORE})) {
+        if (state.getInventory().has(ItemID.GOLD_ORE)) {
 
-            if (state.getInventory().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-                !state.getEquipment().equipped(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
-                return equipSmithingCape;
-            }
-
-            if (!state.getEquipment().equipped(new int[]{ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+            if (!state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
                 return equipGoldsmithGauntlets;
             }
 
@@ -53,19 +53,19 @@ public class GoldBarMethod extends Method
             return waitForBars;
         }
 
-        if (state.getFurnace().has(new int[]{ItemID.GOLD_BAR})) {
-            if (!state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (state.getFurnace().has(ItemID.GOLD_BAR)) {
+            if (!state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
                 return equipIceOrSmithsGloves;
             }
             return collectBars;
         }
 
         if (state.getBank().isOpen()) {
-            if (state.getInventory().has(new int[]{ItemID.GOLD_BAR})) {
+            if (state.getInventory().has(ItemID.GOLD_BAR)) {
                 return depositInventory;
             }
 
-            if (!state.getInventory().has(new int[]{ItemID.GOLD_ORE})) {
+            if (!state.getInventory().has(ItemID.GOLD_ORE)) {
                 return withdrawGoldOre;
             }
         }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -21,7 +21,11 @@ abstract public class GoldHybridMethod extends MetalBarMethod
         }
 
         if (!state.getInventory().has(ItemID.GOLDSMITH_GAUNTLETS) &&
-            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS)) {
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPE) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawGoldsmithGauntlets : openBank;
         }
 
@@ -44,7 +48,9 @@ abstract public class GoldHybridMethod extends MetalBarMethod
         // then do one trip of metal bars
 
         if (state.getInventory().has(ItemID.GOLD_ORE) &&
-            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS)) {
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPET)) {
             return equipGoldsmithGauntlets;
         }
 
@@ -87,7 +93,7 @@ abstract public class GoldHybridMethod extends MetalBarMethod
                 return putOntoConveyorBelt;
             }
 
-            if (state.getFurnace().getQuantity(ItemID.COAL) < 26 * (coalPer() - 1)) {
+            if (state.getFurnace().getQuantity(ItemID.COAL) < 26 * (coalPer() - coalOffset)) {
                 return withdrawGoldOre;
             }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -8,27 +8,32 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 {
     private MethodStep checkPrerequisite(BlastFurnaceState state)
     {
-        if (!state.getInventory().has(new int[]{ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG})) {
+        if (!state.getInventory().has(ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG)) {
             return state.getBank().isOpen() ? withdrawCoalBag : openBank;
         }
 
-        if (!state.getInventory().has(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (!state.getInventory().has(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) &&
+            !state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
             return state.getBank().isOpen() ? withdrawIceOrSmithsGloves : openBank;
         }
 
-        if (state.getBank().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getInventory().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (state.getBank().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getInventory().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawSmithingCape : openBank;
         }
 
-        if (!state.getInventory().has(new int[]{ItemID.GOLDSMITH_GAUNTLETS}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.GOLDSMITH_GAUNTLETS})) {
+        if (state.getInventory().has(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) &&
+            !state.getEquipment().equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
+            return equipSmithingCape;
+        }
+
+        if (!state.getInventory().has(ItemID.GOLDSMITH_GAUNTLETS) &&
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return state.getBank().isOpen() ? withdrawGoldsmithGauntlets : openBank;
         }
 
-        if (!state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I, ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (!state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I, ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return equipGoldsmithGauntlets;
         }
 
@@ -44,17 +49,12 @@ abstract public class GoldHybridMethod extends MetalBarMethod
         // continue doing gold bars until enough coal has been deposited
         // then do one trip of metal bars
 
-        if (state.getInventory().has(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
-            return equipSmithingCape;
-        }
-
-        if (state.getInventory().has(new int[]{ItemID.GOLD_ORE}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (state.getInventory().has(ItemID.GOLD_ORE) &&
+            !state.getEquipment().equipped(ItemID.GOLDSMITH_GAUNTLETS, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             return equipGoldsmithGauntlets;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.COAL, ItemID.GOLD_ORE, oreItem()})) {
+        if (state.getInventory().has(ItemID.COAL, ItemID.GOLD_ORE, oreItem())) {
             return putOntoConveyorBelt;
         }
 
@@ -67,15 +67,15 @@ abstract public class GoldHybridMethod extends MetalBarMethod
             return waitForBars;
         }
 
-        if (state.getFurnace().has(new int[]{barItem(), ItemID.GOLD_BAR})) {
-            if (!state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (state.getFurnace().has(barItem(), ItemID.GOLD_BAR)) {
+            if (!state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
                 return equipIceOrSmithsGloves;
             }
             return collectBars;
         }
 
         if (state.getBank().isOpen()) {
-            if (state.getInventory().has(new int[]{ItemID.GOLD_BAR, barItem()})) {
+            if (state.getInventory().has(ItemID.GOLD_BAR, barItem())) {
                 return depositInventory;
             }
 
@@ -83,15 +83,15 @@ abstract public class GoldHybridMethod extends MetalBarMethod
                 return state.getCoalBag().isEmpty() ? fillCoalBag : refillCoalBag;
             }
 
-            if (state.getInventory().has(new int[]{ItemID.GOLD_ORE, oreItem()})) {
+            if (state.getInventory().has(ItemID.GOLD_ORE, oreItem())) {
                 return putOntoConveyorBelt;
             }
 
-            if (state.getFurnace().getQuantity(new int[]{ItemID.COAL}) < 26 * (coalPer() - state.getFurnace().getCoalOffset())) {
+            if (state.getFurnace().getQuantity(ItemID.COAL) < 26 * (coalPer() - state.getFurnace().getCoalOffset())) {
                 return withdrawGoldOre;
             }
 
-            if (!state.getInventory().has(new int[]{oreItem()})) {
+            if (!state.getInventory().has(oreItem())) {
                 return withdrawOre();
             }
         }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -54,7 +54,7 @@ abstract public class MetalBarMethod extends Method
         }
 
         if (state.getPlayer().isAtConveyorBelt() &&
-            state.getCoalBag().isFull()) {
+            !state.getCoalBag().isEmpty()) {
             return emptyCoalBag;
         }
 
@@ -79,7 +79,7 @@ abstract public class MetalBarMethod extends Method
                 return putOntoConveyorBelt;
             }
 
-            if (state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - 1)) {
+            if (state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - coalOffset)) {
                 return withdrawCoal;
             }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -22,16 +22,16 @@ abstract public class MetalBarMethod extends Method
 
     private MethodStep checkPrerequisite(BlastFurnaceState state)
     {
-        if (!state.getInventory().has(new int[]{ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG})) {
+        if (!state.getInventory().has(ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG)) {
             return state.getBank().isOpen() ? withdrawCoalBag : openBank;
         }
 
-        if (!state.getInventory().has(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I}) &&
-            !state.getEquipment().equipped(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (!state.getInventory().has(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) &&
+            !state.getEquipment().equipped(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
             return state.getBank().isOpen() ? withdrawIceOrSmithsGloves : openBank;
         }
 
-        if (state.getInventory().has(new int[]{ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I})) {
+        if (state.getInventory().has(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I)) {
             return equipIceOrSmithsGloves;
         }
 
@@ -44,7 +44,7 @@ abstract public class MetalBarMethod extends Method
         MethodStep prerequisite = checkPrerequisite(state);
         if (prerequisite != null) return prerequisite;
 
-        if (state.getInventory().has(new int[]{ItemID.COAL, oreItem()})) {
+        if (state.getInventory().has(ItemID.COAL, oreItem())) {
             return putOntoConveyorBelt;
         }
 
@@ -57,12 +57,12 @@ abstract public class MetalBarMethod extends Method
             return waitForBars;
         }
 
-        if (state.getFurnace().has(new int[]{barItem()})) {
+        if (state.getFurnace().has(barItem())) {
             return collectBars;
         }
 
         if (state.getBank().isOpen()) {
-            if (state.getInventory().has(new int[]{barItem()})) {
+            if (state.getInventory().has(barItem())) {
                 return depositInventory;
             }
 
@@ -70,15 +70,15 @@ abstract public class MetalBarMethod extends Method
                 return fillCoalBag;
             }
 
-            if (state.getInventory().has(new int[]{ItemID.COAL})) {
+            if (state.getInventory().has(ItemID.COAL)) {
                 return putOntoConveyorBelt;
             }
 
-            if (state.getFurnace().getQuantity(new int[]{ItemID.COAL}) < 27 * (coalPer() -  state.getFurnace().getCoalOffset())) {
+            if (state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() -  state.getFurnace().getCoalOffset())) {
                 return withdrawCoal;
             }
 
-            if (!state.getInventory().has(new int[]{oreItem()})) {
+            if (!state.getInventory().has(oreItem())) {
                 return withdrawOre();
             }
         }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -23,8 +23,8 @@ public abstract class Method
 
     protected final MethodStep withdrawIceOrSmithsGloves = new ItemStep(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I, "Withdraw ice gloves or smiths gloves (i)");
     protected final MethodStep equipIceOrSmithsGloves = new ItemStep(ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I, "Equip ice gloves or smiths gloves (i)");
-    protected final MethodStep withdrawGoldsmithGauntlets = new ItemStep(ItemID.GOLDSMITH_GAUNTLETS, "Withdraw goldsmith gauntlets");
-    protected final MethodStep equipGoldsmithGauntlets = new ItemStep(ItemID.GOLDSMITH_GAUNTLETS, "Equip goldsmith gauntlets");
+    protected final MethodStep withdrawGoldsmithGauntlets = new ItemStep(ItemID.GOLDSMITH_GAUNTLETS, "Withdraw goldsmith gauntlets or Smithing cape");
+    protected final MethodStep equipGoldsmithGauntlets = new ItemStep(ItemID.GOLDSMITH_GAUNTLETS, "Equip goldsmith gauntlets or Smithing cape");
 
     // objects
     protected final MethodStep depositInventory = new WidgetStep(WidgetInfo.BANK_DEPOSIT_INVENTORY, "Deposit inventory");
@@ -32,6 +32,8 @@ public abstract class Method
     protected final MethodStep openBank = new ObjectStep(EasyBlastFurnacePlugin.BANK_CHEST, "Open bank chest");
     protected final MethodStep collectBars = new ObjectStep(EasyBlastFurnacePlugin.BAR_DISPENSER, "Collect bars");
     protected final MethodStep waitForBars = new TileStep(EasyBlastFurnacePlugin.PICKUP_POSITION, "Wait for bars to smelt");
+
+    public int coalOffset = 1;
 
     abstract public MethodStep next(BlastFurnaceState state);
 

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BankState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BankState.java
@@ -29,7 +29,7 @@ public class BankState
         return bankContainer != null && !bankContainer.isHidden();
     }
 
-    public int getQuantity(int[] itemIds)
+    public int getQuantity(int ...itemIds)
     {
         load();
         int total = 0;
@@ -41,5 +41,5 @@ public class BankState
         return total;
     }
 
-    public boolean has(int[] itemIds) { return getQuantity(itemIds) > 0; }
+    public boolean has(int ...itemIds) { return getQuantity(itemIds) > 0; }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -39,11 +39,11 @@ public class BlastFurnaceState
             player.hasLoadedOres(true);
         }
 
-        if (furnace.has(new int[]{ItemID.GOLD_BAR, ItemID.STEEL_BAR, ItemID.MITHRIL_BAR, ItemID.ADAMANTITE_BAR, ItemID.RUNITE_BAR})) {
+        if (furnace.has(ItemID.GOLD_BAR, ItemID.STEEL_BAR, ItemID.MITHRIL_BAR, ItemID.ADAMANTITE_BAR, ItemID.RUNITE_BAR)) {
             player.hasLoadedOres(false);
         }
 
-        if (equipment.equipped(new int[]{ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET})) {
+        if (equipment.equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET)) {
             coalBag.setMaxCoal(36);
         } else {
             coalBag.setMaxCoal(27);

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -47,6 +47,12 @@ public class BlastFurnaceState
             player.hasLoadedOres(false);
         }
 
+        if (equipment.equipped(ItemID.SMITHING_CAPE) || equipment.equipped(ItemID.SMITHING_CAPET)) {
+            coalBag.setMaxCoal(36);
+        } else {
+            coalBag.setMaxCoal(27);
+        }
+
         inventory.update();
         furnace.update();
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -7,7 +7,7 @@ import javax.inject.Inject;
 
 public class CoalBagState
 {
-    private static final int MAX_COAL = 27;
+    private static int MAX_COAL = 27;
     private static final int MIN_COAL = 0;
 
     @Inject
@@ -18,6 +18,11 @@ public class CoalBagState
 
     @Getter
     private int coal;
+
+    public void setMaxCoal(int quantity)
+    {
+        MAX_COAL = quantity;
+    }
 
     public void setCoal(int quantity)
     {

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -58,6 +58,6 @@ public class CoalBagState
             return;
         }
 
-        setCoal(coal + inventory.getQuantity(new int[]{ItemID.COAL}));
+        setCoal(coal + inventory.getQuantity(ItemID.COAL));
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/EquipmentState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/EquipmentState.java
@@ -21,7 +21,7 @@ public class EquipmentState
         }
     }
 
-    public boolean equipped(int[] itemIds)
+    public boolean equipped(int ...itemIds)
     {
         load();
         int total = 0;

--- a/src/main/java/com/toofifty/easyblastfurnace/state/FurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/FurnaceState.java
@@ -23,13 +23,13 @@ public class FurnaceState
     public void update()
     {
         for (BarsOres varbit : BarsOres.values()) {
-            previousQuantity.put(varbit.getItemID(), getQuantity(new int[]{varbit.getItemID()}));
+            previousQuantity.put(varbit.getItemID(), getQuantity(varbit.getItemID()));
         }
     }
 
     public int getChange(int itemId)
     {
-        return getQuantity(new int[]{itemId}) - previousQuantity.getOrDefault(itemId, 0);
+        return getQuantity(itemId) - previousQuantity.getOrDefault(itemId, 0);
     }
 
 
@@ -41,7 +41,7 @@ public class FurnaceState
         return 1;
     }
 
-    public int getQuantity(int[] itemIds)
+    public int getQuantity(int ...itemIds)
     {
         int total = 0;
 
@@ -54,5 +54,5 @@ public class FurnaceState
         return total;
     }
 
-    public boolean has(int[] itemIds) { return getQuantity(itemIds) > 0; }
+    public boolean has(int ...itemIds) { return getQuantity(itemIds) > 0; }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/InventoryState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/InventoryState.java
@@ -44,7 +44,7 @@ public class InventoryState
 
     public int getChange(int itemId)
     {
-        return getQuantity(new int[]{itemId}) - getPreviousQuantity(itemId);
+        return getQuantity(itemId) - getPreviousQuantity(itemId);
     }
 
     public boolean hasChanged(int itemId)
@@ -52,7 +52,7 @@ public class InventoryState
         return getChange(itemId) != 0;
     }
 
-    public int getQuantity(int[] itemIds)
+    public int getQuantity(int ...itemIds)
     {
         load();
         int total = 0;
@@ -64,7 +64,7 @@ public class InventoryState
         return total;
     }
 
-    public boolean has(int[] itemIds) { return getQuantity(itemIds) > 0; }
+    public boolean has(int ...itemIds) { return getQuantity(itemIds) > 0; }
 
     public int getFreeSlots()
     {

--- a/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
@@ -46,7 +46,11 @@ public class PlayerState
 
     public boolean hasStamina()
     {
-        return client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0;
+        if (config.ignoreRemainingPotion()) {
+            return false;
+        } else {
+            return client.getVarbitValue(Varbits.RUN_SLOWED_DEPLETION_ACTIVE) != 0;
+        }
     }
 
     public boolean needsStamina()

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
@@ -31,6 +31,12 @@ public class MethodHandler
         if (method == null) return;
         if (!state.getPlayer().isOnBlastFurnaceWorld()) return;
 
+        if (config.addCoalBuffer()) {
+            method.coalOffset = 0;
+        } else {
+            method.coalOffset = 1;
+        }
+
         step = drinkStaminaMethod.next(state);
         if (step == null) step = method.next(state);
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
@@ -43,7 +43,7 @@ public class MethodHandler
 
     private boolean inInventory(int itemId)
     {
-        return state.getInventory().has(new int[]{itemId});
+        return state.getInventory().has(itemId);
     }
 
     private Method getMethodFromInventory()


### PR DESCRIPTION
- Added checks for the smithing cape when checking for goldsmith gauntlets as the smithing cape can be used instead of the gloves.

- Allowed MAX_COAL variable to be changed if smithing cape is equipped (coal bag contains a max of 36 coal with smithing cape, 27 without).

- Added option to ignore the remaining stamina potion timer if the Low energy threshold has been reached (off by default).

- Added option for a coal buffer that leaves extra coal in the furnace to ensure bars always get smelted in the same game tick (off by default).

- Bumped runeLiteVersion from '1.8.25' -> '1.8.31'.