### PR TITLE
Coal bag count fix

### DIFF
--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -53,6 +53,10 @@ public class BlastFurnaceState
             coalBag.setMaxCoal(27);
         }
 
+        if (coalBag.getOreOntoConveyorCount() > 0 && bank.isOpen() && inventory.hasChanged(ItemID.COAL) && inventory.has(ItemID.COAL)) {
+            coalBag.oreOntoConveyor(0);
+        }
+
         inventory.update();
         furnace.update();
     }


### PR DESCRIPTION
Problem: oreOntoConveyorCount gets out of sync if the player forgets to empty their coal bag.

Solution: When the player adds coal into their inventory while in the bank, reset oreOntoConveyorCount to 0. That way it's always correct even if the player makes mistakes.