### PR TITLE
Fix for method steps not ensuring double XP for gold

### DIFF
--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -60,13 +60,13 @@ public class GoldBarMethod extends Method
         }
 
         if (state.getPlayer().hasLoadedOres()) {
-            if (!state.getEquipment().hasIceGlovesEffect()) {
-                return equipIceOrSmithsGloves;
-            }
             return waitForBars;
         }
 
         if (state.getFurnace().has(ItemID.GOLD_BAR)) {
+            if (!state.getEquipment().hasIceGlovesEffect()) {
+                return equipIceOrSmithsGloves;
+            }
             return collectBars;
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -74,13 +74,13 @@ abstract public class GoldHybridMethod extends MetalBarMethod
         }
 
         if (state.getPlayer().hasLoadedOres()) {
-            if (!state.getEquipment().hasIceGlovesEffect()) {
-                return equipIceOrSmithsGloves;
-            }
             return waitForBars;
         }
 
         if (state.getFurnace().has(barItem(), ItemID.GOLD_BAR)) {
+            if (!state.getEquipment().hasIceGlovesEffect()) {
+                return equipIceOrSmithsGloves;
+            }
             return collectBars;
         }
 

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -233,13 +233,13 @@ public class EasyBlastFurnacePluginTest {
         setWorldPoint(atConveyorBelt);
         setInventoryCount(ItemID.GOLD_ORE, 0);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 1);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
-
-        equipGloves(true);
         assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+
+        equipGloves(true);
         assertStepTooltip(Strings.COLLECT_BARS);
 
         setWorldPoint(notAtConveyorBelt);
@@ -453,13 +453,13 @@ public class EasyBlastFurnacePluginTest {
         setCoalBag(Strings.EMPTY);
         assertEquals(1, state.getCoalBag().getCoal());
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
-
-        equipGloves(true);
         assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 1);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+
+        equipGloves(true);
         assertStepTooltip(Strings.COLLECT_BARS);
 
         collectBars(barID, barVarbit);


### PR DESCRIPTION
Move ice glove check to after gold bars have been smelted, to ensure goldsmith glove double xp bonus actually gets applied.

closes #20