### PR TITLE
Fix for #23 - stamina potion management not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.9.1'
+def runeLiteVersion = '1.9.6'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
@@ -5,13 +5,14 @@ import com.toofifty.easyblastfurnace.utils.StaminaHelper;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 
 import javax.inject.Inject;
 import java.util.Arrays;
-
+@Slf4j
 public class PlayerState
 {
     private static final WorldPoint LOAD_POSITION = new WorldPoint(1942, 4967, 0);
@@ -48,7 +49,7 @@ public class PlayerState
             return true;
         }
 
-        return (client.getEnergy() - staminaHelper.getEnergyNeededForNextRun()) > config.requireStaminaThreshold();
+        return (client.getEnergy() / 100.0 - staminaHelper.getEnergyNeededForNextRun()) > config.requireStaminaThreshold();
     }
 
     public boolean isOnBlastFurnaceWorld()

--- a/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
@@ -5,14 +5,13 @@ import com.toofifty.easyblastfurnace.utils.StaminaHelper;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 
 import javax.inject.Inject;
 import java.util.Arrays;
-@Slf4j
+
 public class PlayerState
 {
     private static final WorldPoint LOAD_POSITION = new WorldPoint(1942, 4967, 0);

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -274,12 +274,12 @@ public class EasyBlastFurnacePluginTest {
 
         // deposit inventory
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(50);
-        when(client.getEnergy()).thenReturn(64);
+        when(client.getEnergy()).thenReturn(6400);
         setInventoryCount(ItemID.VIAL, 1);
         assertStepTooltip(Strings.DEPOSIT_POTIONS);
 
         // Second deposit Inventory
-        when(client.getEnergy()).thenReturn(49);
+        when(client.getEnergy()).thenReturn(4900);
         Item[] gold = new Item[28];
         for (int i = 0; i < 28; i++) {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);


### PR DESCRIPTION
This PR fixes stamina potion management (#23). One of the recent Runelite updates included a change to client.getEnergy(), and this addresses that change.

It's basically a 1-liner fix. Just needed to add / 100.