### PR TITLE
Release/1.4.3 tick perfect methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Helps you train at the blast furnace more efficiently
 ## Features
 
 - Supports multiple different methods
-    - Gold bars
+    - Gold bars (tick perfect method is an option in the settings)
     - [Steel/Mithril/Adamant/Rune bars](https://oldschool.runescape.wiki/w/Blast_Furnace#Bar_Patterns)
     - [Gold + metal bar hybrid](https://oldschool.runescape.wiki/w/Blast_Furnace#Hybrid_Method_(Gold/Mithril+))
 - Shows next item/object to click

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.toofifty'
-version = '1.4.2'
+version = '1.4.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnaceConfig.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnaceConfig.java
@@ -116,8 +116,8 @@ public interface EasyBlastFurnaceConfig extends Config
 	@ConfigItem(
 		position = 8,
 		keyName = "leaveBarInDispenser",
-		name = "Toggle tick perfect method",
-		description = "Continues to the next step when there is 1 bar in the dispenser rather than 0",
+		name = "Toggle tick perfect methods",
+		description = "Enable tick perfect gold method and efficient metal/gold hybrid methods.",
 		section = guidanceOverlays
 	)
 	default boolean tickPerfectMethod() { return false; }

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
@@ -208,6 +208,9 @@ public class EasyBlastFurnacePlugin extends Plugin
 
         if (filledMatcher.matches() && state.getBank().isOpen()) {
             state.getCoalBag().fill();
+        } else if (filledMatcher.matches()) {
+            int addedCoal = Integer.parseInt(filledMatcher.group(1));
+            state.getCoalBag().setCoal(state.getCoalBag().getCoal() + addedCoal);
         }
 
         // handle coal bag changes

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
@@ -210,9 +210,6 @@ public class EasyBlastFurnacePlugin extends Plugin
         Matcher emptyMatcher = COAL_EMPTY_MESSAGE.matcher(message);
         Matcher filledMatcher = COAL_FULL_MESSAGE.matcher(message);
 
-        if (filledMatcher.matches() && state.getBank().isOpen()) {
-            state.getCoalBag().fill();
-        } else if (filledMatcher.matches()) {
         if (emptyMatcher.matches()) {
             state.getCoalBag().empty();
         }
@@ -247,9 +244,6 @@ public class EasyBlastFurnacePlugin extends Plugin
 
         if (event.getMenuOption().equals(Strings.DRINK)) statistics.drinkStamina();
         if (event.getMenuOption().equals(Strings.FILL)) state.getCoalBag().fill();
-        if (event.getMenuOption().equals(Strings.FILL)) {
-            state.getCoalBag().fill();
-        }
 
         // Because menu option events can happen multiple times per tick, this is needed to prevent duplicate coal bag empty events.
         final int currentTick = client.getTickCount();

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
@@ -243,7 +243,6 @@ public class EasyBlastFurnacePlugin extends Plugin
         if (!isEnabled) return;
 
         if (event.getMenuOption().equals(Strings.DRINK)) statistics.drinkStamina();
-        if (event.getMenuOption().equals(Strings.FILL)) state.getCoalBag().fill();
 
         // Because menu option events can happen multiple times per tick, this is needed to prevent duplicate coal bag empty events.
         final int currentTick = client.getTickCount();

--- a/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePlugin.java
@@ -23,6 +23,8 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @PluginDescriptor(
@@ -36,6 +38,8 @@ public class EasyBlastFurnacePlugin extends Plugin
     public static final int BANK_CHEST = ObjectID.BANK_CHEST_26707;
 
     public static final WorldPoint PICKUP_POSITION = new WorldPoint(1940, 4962, 0);
+
+    private static final Pattern COAL_FULL_MESSAGE = Pattern.compile(Strings.COAL_FULL);
 
     @Inject
     private Client client;
@@ -191,6 +195,23 @@ public class EasyBlastFurnacePlugin extends Plugin
         if(Objects.equals(event.getGroup(), "easy-blastfurnace") && Objects.equals(event.getKey(), "potionMode")) {
             clientThread.invokeLater(() -> methodHandler.next());
         }
+    }
+
+    @Subscribe
+    public void onChatMessage(ChatMessage event)
+    {
+        if (!isEnabled) return;
+        if (event.getType() != ChatMessageType.GAMEMESSAGE && event.getType() != ChatMessageType.SPAM) return;
+
+        String message = event.getMessage();
+        Matcher filledMatcher = COAL_FULL_MESSAGE.matcher(message);
+
+        if (filledMatcher.matches() && state.getBank().isOpen()) {
+            state.getCoalBag().fill();
+        }
+
+        // handle coal bag changes
+        methodHandler.next();
     }
 
     @Subscribe

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/AdamantiteBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/AdamantiteBarMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class AdamantiteBarMethod extends MetalBarMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawAdamantiteOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/AdamantiteHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/AdamantiteHybridMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class AdamantiteHybridMethod extends GoldHybridMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawAdamantiteOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/DrinkPotionMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/DrinkPotionMethod.java
@@ -10,44 +10,44 @@ import net.runelite.api.ItemID;
 public class DrinkPotionMethod extends Method
 {
     // Stamina
-    private final MethodStep withdrawStaminaPotion1 = new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION1);
-    private final MethodStep withdrawStaminaPotion2 = new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION2);
-    private final MethodStep withdrawStaminaPotion3 = new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION3);
-    private final MethodStep withdrawStaminaPotion4 = new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION4);
+    private final MethodStep[] withdrawStaminaPotion1 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION1) };
+    private final MethodStep[] withdrawStaminaPotion2 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION2) };
+    private final MethodStep[] withdrawStaminaPotion3 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION3) };
+    private final MethodStep[] withdrawStaminaPotion4 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_STAMINA_POTION, ItemID.STAMINA_POTION4) };
 
-    private final MethodStep drinkStaminaPotion1 = new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION1);
-    private final MethodStep drinkStaminaPotion2 = new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION2);
-    private final MethodStep drinkStaminaPotion3 = new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION3);
-    private final MethodStep drinkStaminaPotion4 = new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION4);
-    private final MethodStep getMoreStaminaPotions = new ItemStep(Strings.GET_MORE_STAMINA_POTIONS, ItemID.COAL_BAG_12019);
+    private final MethodStep[] drinkStaminaPotion1 = new MethodStep[] { new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION1) };
+    private final MethodStep[] drinkStaminaPotion2 = new MethodStep[] { new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION2) };
+    private final MethodStep[] drinkStaminaPotion3 = new MethodStep[] { new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION3) };
+    private final MethodStep[] drinkStaminaPotion4 = new MethodStep[] { new ItemStep(Strings.DRINK_STAMINA_POTION, ItemID.STAMINA_POTION4) };
+    private final MethodStep[] getMoreStaminaPotions = new MethodStep[] { new ItemStep(Strings.GET_MORE_STAMINA_POTIONS, ItemID.COAL_BAG_12019) };
 
 
     // Super Energy
-    private final MethodStep withdrawSuperEnergyPotion1 = new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY1);
-    private final MethodStep withdrawSuperEnergyPotion2 = new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY2);
-    private final MethodStep withdrawSuperEnergyPotion3 = new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY3);
-    private final MethodStep withdrawSuperEnergyPotion4 = new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY4);
+    private final MethodStep[] withdrawSuperEnergyPotion1 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY1) };
+    private final MethodStep[] withdrawSuperEnergyPotion2 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY2) };
+    private final MethodStep[] withdrawSuperEnergyPotion3 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY3) };
+    private final MethodStep[] withdrawSuperEnergyPotion4 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY4) };
 
-    private final MethodStep drinkSuperEnergyPotion1 = new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY1);
-    private final MethodStep drinkSuperEnergyPotion2 = new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY2);
-    private final MethodStep drinkSuperEnergyPotion3 = new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY3);
-    private final MethodStep drinkSuperEnergyPotion4 = new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY4);
-    private final MethodStep getMoreSuperEnergyPotions = new ItemStep(Strings.GET_MORE_SUPER_ENERGY_POTIONS, ItemID.COAL_BAG_12019);
+    private final MethodStep[] drinkSuperEnergyPotion1 = new MethodStep[] { new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY1) };
+    private final MethodStep[] drinkSuperEnergyPotion2 = new MethodStep[] { new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY2) };
+    private final MethodStep[] drinkSuperEnergyPotion3 = new MethodStep[] { new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY3) };
+    private final MethodStep[] drinkSuperEnergyPotion4 = new MethodStep[] { new ItemStep(Strings.DRINK_SUPER_ENERGY_POTION, ItemID.SUPER_ENERGY4) };
+    private final MethodStep[] getMoreSuperEnergyPotions = new MethodStep[] { new ItemStep(Strings.GET_MORE_SUPER_ENERGY_POTIONS, ItemID.COAL_BAG_12019) };
 
     // Energy
-    private final MethodStep withdrawEnergyPotion1 = new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION1);
-    private final MethodStep withdrawEnergyPotion2 = new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION2);
-    private final MethodStep withdrawEnergyPotion3 = new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION3);
-    private final MethodStep withdrawEnergyPotion4 = new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION4);
+    private final MethodStep[] withdrawEnergyPotion1 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION1) };
+    private final MethodStep[] withdrawEnergyPotion2 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION2) };
+    private final MethodStep[] withdrawEnergyPotion3 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION3) };
+    private final MethodStep[] withdrawEnergyPotion4 = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ENERGY_POTION, ItemID.ENERGY_POTION4) };
 
-    private final MethodStep drinkEnergyPotion1 = new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION1);
-    private final MethodStep drinkEnergyPotion2 = new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION2);
-    private final MethodStep drinkEnergyPotion3 = new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION3);
-    private final MethodStep drinkEnergyPotion4 = new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION4);
-    private final MethodStep getMoreEnergyPotions = new ItemStep(Strings.GET_MORE_ENERGY_POTIONS, ItemID.COAL_BAG_12019);
+    private final MethodStep[] drinkEnergyPotion1 = new MethodStep[] { new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION1) };
+    private final MethodStep[] drinkEnergyPotion2 = new MethodStep[] { new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION2) };
+    private final MethodStep[] drinkEnergyPotion3 = new MethodStep[] { new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION3) };
+    private final MethodStep[] drinkEnergyPotion4 = new MethodStep[] { new ItemStep(Strings.DRINK_ENERGY_POTION, ItemID.ENERGY_POTION4) };
+    private final MethodStep[] getMoreEnergyPotions = new MethodStep[] { new ItemStep(Strings.GET_MORE_ENERGY_POTIONS, ItemID.COAL_BAG_12019) };
 
     @Override
-    public MethodStep next(BlastFurnaceState state)
+    public MethodStep[] next(BlastFurnaceState state)
     {
         switch(state.getConfig().potionOverlayMode()) {
             case SUPER_ENERGY: return GetSuperEnergyStep(state);
@@ -56,7 +56,7 @@ public class DrinkPotionMethod extends Method
         }
     }
 
-    private MethodStep GetStaminaStep(BlastFurnaceState state) {
+    private MethodStep[] GetStaminaStep(BlastFurnaceState state) {
         if (state.getPlayer().hasEnoughEnergy() &&
                 (state.getInventory().has(ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3, ItemID.STAMINA_POTION4))) {
             return state.getConfig().useDepositInventory() ? depositInventory : depositStaminaPotions;
@@ -104,7 +104,7 @@ public class DrinkPotionMethod extends Method
         return getMoreStaminaPotions;
     }
 
-    private MethodStep GetSuperEnergyStep(BlastFurnaceState state) {
+    private MethodStep[] GetSuperEnergyStep(BlastFurnaceState state) {
         if (state.getPlayer().hasEnoughEnergy() &&
                 (state.getInventory().has(ItemID.VIAL, ItemID.SUPER_ENERGY1, ItemID.SUPER_ENERGY2, ItemID.SUPER_ENERGY3, ItemID.SUPER_ENERGY4))) {
             return state.getConfig().useDepositInventory() ? depositInventory : depositSuperEnergyPotions;
@@ -154,7 +154,7 @@ public class DrinkPotionMethod extends Method
         return getMoreSuperEnergyPotions;
     }
 
-    private MethodStep GetEnergyStep(BlastFurnaceState state) {
+    private MethodStep[] GetEnergyStep(BlastFurnaceState state) {
         if (state.getPlayer().hasEnoughEnergy() &&
                 (state.getInventory().has(ItemID.VIAL, ItemID.ENERGY_POTION1, ItemID.ENERGY_POTION2, ItemID.ENERGY_POTION3, ItemID.ENERGY_POTION4))) {
             return state.getConfig().useDepositInventory() ? depositInventory : depositEnergyPotions;

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -57,7 +57,7 @@ public class GoldBarMethod extends Method
         boolean atConveyorBelt = state.getPlayer().isAtConveyorBelt();
 
         if (tickPerfectMethod && state.getInventory().has(ItemID.GOLD_ORE)) {
-            if (state.getBank().isOpen()) {
+            if (furnaceHasBar) {
                 return putOntoConveyorBelt;
             } else {
                 return putOntoConveyorBeltAndEquipGoldsmithGauntlets;
@@ -97,6 +97,10 @@ public class GoldBarMethod extends Method
         if (state.getBank().isOpen()) {
             if (state.getInventory().has(ItemID.GOLD_BAR)) {
                 return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
+            }
+
+            if (tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect() && !state.getEquipment().hasIceGlovesEffect()) {
+                return equipGoldsmithGauntlets;
             }
 
             if (!tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect()) {

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -3,8 +3,9 @@ package com.toofifty.easyblastfurnace.methods;
 import com.toofifty.easyblastfurnace.state.BlastFurnaceState;
 import com.toofifty.easyblastfurnace.steps.MethodStep;
 import com.toofifty.easyblastfurnace.utils.Strings;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
-
+@Slf4j
 public class GoldBarMethod extends Method
 {
     private MethodStep[] checkPrerequisite(BlastFurnaceState state)
@@ -52,8 +53,30 @@ public class GoldBarMethod extends Method
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
         boolean furnaceHasBar = state.getFurnace().has(ItemID.GOLD_BAR);
         boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
+        boolean atBarDispenser = state.getPlayer().isAtBarDispenser();
+        boolean atConveyorBelt = state.getPlayer().isAtConveyorBelt();
 
-        if (state.getInventory().has(ItemID.GOLD_ORE)) {
+        if (tickPerfectMethod && state.getInventory().has(ItemID.GOLD_ORE)) {
+            if (state.getBank().isOpen()) {
+                return putOntoConveyorBelt;
+            } else {
+                return putOntoConveyorBeltAndEquipGoldsmithGauntlets;
+            }
+        }
+
+        if (tickPerfectMethod && oreOnConveyor && furnaceHasBar) {
+            if (atConveyorBelt) {
+                return goToDispenser;
+            }
+
+            if (!atBarDispenser) {
+                return goToDispenserAndEquipIceOrSmithsGloves;
+            }
+
+            return collectBarsAndEquipGoldsmithGauntlets;
+        }
+
+        if (!tickPerfectMethod && state.getInventory().has(ItemID.GOLD_ORE)) {
             if (!state.getEquipment().hasGoldsmithEffect()) {
                 return equipGoldsmithGauntlets;
             }
@@ -61,16 +84,8 @@ public class GoldBarMethod extends Method
         }
 
 		if (!tickPerfectMethod && oreOnConveyor) {
-			return waitForBars;
+			return waitForGoldBars;
 		}
-
-        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser() && oreOnConveyor) {
-            return goToDispenserAndEquipIceOrSmithsGloves;
-        }
-
-        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser() && (oreOnConveyor || furnaceHasBar)) {
-            return collectBarsAndEquipGoldsmithGauntlets;
-        }
 
         if (!tickPerfectMethod && furnaceHasBar) {
             if (!state.getEquipment().hasIceGlovesEffect()) {

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -64,11 +64,11 @@ public class GoldBarMethod extends Method
 			return waitForBars;
 		}
 
-        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser()) {
+        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser() && oreOnConveyor) {
             return goToDispenserAndEquipIceOrSmithsGloves;
         }
 
-        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser()) {
+        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser() && (oreOnConveyor || furnaceHasBar)) {
             return collectBarsAndEquipGoldsmithGauntlets;
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -7,7 +7,7 @@ import net.runelite.api.ItemID;
 
 public class GoldBarMethod extends Method
 {
-    private MethodStep checkPrerequisite(BlastFurnaceState state)
+    private MethodStep[] checkPrerequisite(BlastFurnaceState state)
     {
         // ensure player has both ice gloves & goldsmith gauntlets either in inventory or equipped
 
@@ -45,9 +45,9 @@ public class GoldBarMethod extends Method
     }
 
     @Override
-    public MethodStep next(BlastFurnaceState state)
+    public MethodStep[] next(BlastFurnaceState state)
     {
-        MethodStep prerequisite = checkPrerequisite(state);
+        MethodStep[] prerequisite = checkPrerequisite(state);
         if (prerequisite != null) return prerequisite;
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
         boolean furnaceHasBar = state.getFurnace().has(ItemID.GOLD_BAR);

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -51,37 +51,40 @@ public class GoldBarMethod extends Method
         if (prerequisite != null) return prerequisite;
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
         boolean furnaceHasBar = state.getFurnace().has(ItemID.GOLD_BAR);
+        boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
 
         if (state.getInventory().has(ItemID.GOLD_ORE)) {
-
             if (!state.getEquipment().hasGoldsmithEffect()) {
                 return equipGoldsmithGauntlets;
             }
-
             return putOntoConveyorBelt;
         }
 
-		if (!state.getConfig().tickPerfectMethod() && oreOnConveyor) {
+		if (!tickPerfectMethod && oreOnConveyor) {
 			return waitForBars;
 		}
 
+        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser()) {
+            return goToDispenserAndEquipIceOrSmithsGloves;
+        }
 
+        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser()) {
+            return collectBarsAndEquipGoldsmithGauntlets;
+        }
 
-		if (state.getConfig().tickPerfectMethod() && furnaceHasBar && oreOnConveyor ||
-			!state.getConfig().tickPerfectMethod() && furnaceHasBar) {
-			if (!state.getEquipment().hasIceGlovesEffect()) {
-				return equipIceOrSmithsGloves;
-			}
-			return collectBars;
-		}
-
+        if (!tickPerfectMethod && furnaceHasBar) {
+            if (!state.getEquipment().hasIceGlovesEffect()) {
+                return equipIceOrSmithsGloves;
+            }
+            return collectBars;
+        }
 
         if (state.getBank().isOpen()) {
             if (state.getInventory().has(ItemID.GOLD_BAR)) {
                 return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
             }
 
-            if (!state.getConfig().tickPerfectMethod() && !state.getEquipment().hasGoldsmithEffect()) {
+            if (!tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect()) {
                 return equipGoldsmithGauntlets;
             }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -5,6 +5,7 @@ import com.toofifty.easyblastfurnace.steps.MethodStep;
 import com.toofifty.easyblastfurnace.utils.Strings;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
+
 @Slf4j
 public class GoldBarMethod extends Method
 {
@@ -59,7 +60,7 @@ public class GoldBarMethod extends Method
         boolean useDepositInventory = state.getConfig().useDepositInventory();
 
         if (state.getBank().isOpen()) {
-            if (furnaceHasOre && furnaceHasBar) {
+            if (furnaceHasOre && furnaceHasBar || (!tickPerfectMethod && furnaceHasBar)) {
                 if (state.getInventory().has(ItemID.GOLD_BAR, ItemID.GOLD_ORE)) {
                     return useDepositInventory ? depositInventory : depositBarsAndOres;
                 }
@@ -110,7 +111,7 @@ public class GoldBarMethod extends Method
             return putOntoConveyorBelt;
         }
 
-		if (!tickPerfectMethod && oreOnConveyor) {
+		if (!tickPerfectMethod && (oreOnConveyor || furnaceHasOre)) {
 			return waitForGoldBars;
 		}
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldBarMethod.java
@@ -52,9 +52,36 @@ public class GoldBarMethod extends Method
         if (prerequisite != null) return prerequisite;
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
         boolean furnaceHasBar = state.getFurnace().has(ItemID.GOLD_BAR);
+        boolean furnaceHasOre = state.getFurnace().has(ItemID.GOLD_ORE);
         boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
         boolean atBarDispenser = state.getPlayer().isAtBarDispenser();
         boolean atConveyorBelt = state.getPlayer().isAtConveyorBelt();
+        boolean useDepositInventory = state.getConfig().useDepositInventory();
+
+        if (state.getBank().isOpen()) {
+            if (furnaceHasOre && furnaceHasBar) {
+                if (state.getInventory().has(ItemID.GOLD_BAR, ItemID.GOLD_ORE)) {
+                    return useDepositInventory ? depositInventory : depositBarsAndOres;
+                }
+                return collectBars;
+            }
+
+            if (state.getInventory().has(ItemID.GOLD_BAR)) {
+                return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
+            }
+
+            if (tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect() && !state.getEquipment().hasIceGlovesEffect()) {
+                return equipGoldsmithGauntlets;
+            }
+
+            if (!tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect()) {
+                return equipGoldsmithGauntlets;
+            }
+
+            if (!state.getInventory().has(ItemID.GOLD_ORE)) {
+                return withdrawGoldOre;
+            }
+        }
 
         if (tickPerfectMethod && state.getInventory().has(ItemID.GOLD_ORE)) {
             if (furnaceHasBar) {
@@ -64,7 +91,7 @@ public class GoldBarMethod extends Method
             }
         }
 
-        if (tickPerfectMethod && oreOnConveyor && furnaceHasBar) {
+        if (tickPerfectMethod && (oreOnConveyor || furnaceHasOre) && furnaceHasBar) {
             if (atConveyorBelt) {
                 return goToDispenser;
             }
@@ -92,24 +119,6 @@ public class GoldBarMethod extends Method
                 return equipIceOrSmithsGloves;
             }
             return collectBars;
-        }
-
-        if (state.getBank().isOpen()) {
-            if (state.getInventory().has(ItemID.GOLD_BAR)) {
-                return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
-            }
-
-            if (tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect() && !state.getEquipment().hasIceGlovesEffect()) {
-                return equipGoldsmithGauntlets;
-            }
-
-            if (!tickPerfectMethod && !state.getEquipment().hasGoldsmithEffect()) {
-                return equipGoldsmithGauntlets;
-            }
-
-            if (!state.getInventory().has(ItemID.GOLD_ORE)) {
-                return withdrawGoldOre;
-            }
         }
 
         return openBank;

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -7,6 +7,7 @@ import net.runelite.api.ItemID;
 @Slf4j
 abstract public class GoldHybridMethod extends MetalBarMethod
 {
+	protected boolean lastInvWasGold = false;
     private MethodStep[] checkPrerequisite(BlastFurnaceState state)
     {
         if (!state.getInventory().has(ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG)) {
@@ -84,7 +85,7 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 				return coalBagEmpty ? fillCoalBag : refillCoalBag;
 			}
 
-			if (state.getFurnace().getQuantity(ItemID.GOLD_ORE, oreItem()) == 28 && state.getInventory().has(oreItem(), ItemID.GOLD_ORE)) {
+			if (furnaceHasMetalBar && furnaceHasGoldBar) {
 				return collectBars;
 			}
 
@@ -93,10 +94,12 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 			}
 
 			if (coalRun && !state.getInventory().has(oreItem(), ItemID.GOLD_ORE)) {
+				lastInvWasGold = true;
 				return withdrawGoldOre;
 			}
 
 			if (!state.getInventory().has(oreItem(), ItemID.GOLD_ORE)) {
+				lastInvWasGold = false;
 				return withdrawOre();
 			}
 
@@ -122,18 +125,16 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 				return goToDispenser;
 			}
 
-			log.info("gold and adamantite bars: " + state.getFurnace().getQuantity(barItem(), ItemID.GOLD_BAR));
-			log.info("gold ore in furnace: " + state.getFurnace().getQuantity(ItemID.GOLD_ORE));
-			if (oreOnConveyor && state.getFurnace().getQuantity(ItemID.GOLD_BAR) < 28 && !furnaceHasMetalBar) {
+			if (furnaceHasGoldBar && oreOnConveyor && !furnaceHasMetalBar && lastInvWasGold && state.getEquipment().hasIceGlovesEffect()) {
+				return collectBarsAndEquipGoldsmithGauntlets;
+			}
+
+			if (oreOnConveyor && lastInvWasGold) {
 				return waitForGoldBars;
 			}
 
 			if (!atBarDispenser) {
 				return goToDispenserAndEquipIceOrSmithsGloves;
-			}
-
-			if (furnaceHasGoldBar && state.getFurnace().getQuantity(ItemID.GOLD_ORE) > 0 && state.getFurnace().getQuantity(barItem(), oreItem()) == 0) {
-				return collectBarsAndEquipGoldsmithGauntlets;
 			}
 
 			return collectBars;

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -102,11 +102,11 @@ abstract public class GoldHybridMethod extends MetalBarMethod
             return waitForBars;
         }
 
-        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser()) {
+        if (tickPerfectMethod && !state.getPlayer().isAtBarDispenser() && (oreOnConveyor || furnaceHasBar)) {
             return goToDispenserAndEquipIceOrSmithsGloves;
         }
 
-        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser()) {
+        if (tickPerfectMethod && state.getPlayer().isAtBarDispenser() && furnaceHasBar) {
             return collectBarsAndEquipGoldsmithGauntlets;
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -6,7 +6,7 @@ import net.runelite.api.ItemID;
 
 abstract public class GoldHybridMethod extends MetalBarMethod
 {
-    private MethodStep checkPrerequisite(BlastFurnaceState state)
+    private MethodStep[] checkPrerequisite(BlastFurnaceState state)
     {
         if (!state.getInventory().has(ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG)) {
             return state.getBank().isOpen() ? withdrawCoalBag : openBank;
@@ -50,9 +50,9 @@ abstract public class GoldHybridMethod extends MetalBarMethod
     }
 
     @Override
-    public MethodStep next(BlastFurnaceState state)
+    public MethodStep[] next(BlastFurnaceState state)
     {
-        MethodStep prerequisite = checkPrerequisite(state);
+        MethodStep[] prerequisite = checkPrerequisite(state);
         if (prerequisite != null) return prerequisite;
         int maxCoalInventory = state.getEquipment().equipped(ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) ? 27 : 26;
         boolean coalRun = state.getFurnace().getQuantity(ItemID.COAL) < maxCoalInventory * (coalPer() - state.getFurnace().getCoalOffset());

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -84,6 +84,14 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 				return coalBagEmpty ? fillCoalBag : refillCoalBag;
 			}
 
+			if (state.getFurnace().getQuantity(ItemID.GOLD_ORE, oreItem()) == 28 && state.getInventory().has(oreItem(), ItemID.GOLD_ORE)) {
+				return collectBars;
+			}
+
+			if (!useDepositInventory && coalRun && !state.getEquipment().hasGoldsmithEffect()) {
+				return equipGoldsmithGauntlets;
+			}
+
 			if (coalRun && !state.getInventory().has(oreItem(), ItemID.GOLD_ORE)) {
 				return withdrawGoldOre;
 			}
@@ -116,12 +124,16 @@ abstract public class GoldHybridMethod extends MetalBarMethod
 
 			log.info("gold and adamantite bars: " + state.getFurnace().getQuantity(barItem(), ItemID.GOLD_BAR));
 			log.info("gold ore in furnace: " + state.getFurnace().getQuantity(ItemID.GOLD_ORE));
-			if (oreOnConveyor && state.getFurnace().getQuantity(barItem(), ItemID.GOLD_BAR) < 28) {
+			if (oreOnConveyor && state.getFurnace().getQuantity(ItemID.GOLD_BAR) < 28 && !furnaceHasMetalBar) {
 				return waitForGoldBars;
 			}
 
 			if (!atBarDispenser) {
 				return goToDispenserAndEquipIceOrSmithsGloves;
+			}
+
+			if (furnaceHasGoldBar && state.getFurnace().getQuantity(ItemID.GOLD_ORE) > 0 && state.getFurnace().getQuantity(barItem(), oreItem()) == 0) {
+				return collectBarsAndEquipGoldsmithGauntlets;
 			}
 
 			return collectBars;

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/GoldHybridMethod.java
@@ -129,7 +129,7 @@ abstract public class GoldHybridMethod extends MetalBarMethod
             return putOntoConveyorBelt;
         }
 
-        if (!barDispenserFull && ((coalBagFull && atConveyorBelt) || (!coalBagEmpty && smithingCapeEquipped)) ) {
+        if (!barDispenserFull && atConveyorBelt && (coalBagFull || (!coalBagEmpty && smithingCapeEquipped)) ) {
             return emptyCoalBag;
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -46,6 +46,7 @@ abstract public class MetalBarMethod extends Method
         boolean coalRun = state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - state.getFurnace().getCoalOffset());
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
         boolean furnaceHasBar = state.getFurnace().has(barItem());
+        boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
 
         if (state.getInventory().has(ItemID.COAL) || (state.getInventory().has(oreItem()) && !coalRun)) {
             return putOntoConveyorBelt;
@@ -56,13 +57,11 @@ abstract public class MetalBarMethod extends Method
             return emptyCoalBag;
         }
 
-        if (!state.getConfig().tickPerfectMethod() && state.getPlayer().hasOreOnConveyor()) {
+        if (!tickPerfectMethod && oreOnConveyor) {
             return waitForBars;
         }
 
-		if (state.getConfig().tickPerfectMethod() && furnaceHasBar && oreOnConveyor ||
-			!state.getConfig().tickPerfectMethod() && furnaceHasBar
-		) {
+		if (furnaceHasBar && (!tickPerfectMethod || oreOnConveyor)) {
 			return collectBars;
 		}
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -45,32 +45,19 @@ abstract public class MetalBarMethod extends Method
         if (prerequisite != null) return prerequisite;
         boolean coalRun = state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - state.getFurnace().getCoalOffset());
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
-        boolean furnaceHasBars = state.getFurnace().has(barItem()) && state.getFurnace().getQuantity(barItem()) >= state.getInventory().getFreeSlotsIncludingOresAndBars();
+        boolean furnaceHasBar = state.getFurnace().has(barItem());
+        boolean furnaceHasOre = state.getFurnace().has(oreItem());
         boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
 
-        if (state.getInventory().has(ItemID.COAL) || (state.getInventory().has(oreItem()) && !coalRun)) {
-            return putOntoConveyorBelt;
-        }
-
-        if (state.getPlayer().isAtConveyorBelt() &&
-            !state.getCoalBag().isEmpty()) {
-            return emptyCoalBag;
-        }
-
-        if (!tickPerfectMethod && oreOnConveyor) {
-            return waitForBars;
-        }
-
-		if (furnaceHasBars && (!tickPerfectMethod || oreOnConveyor)) {
-			return collectBars;
-		}
-
         if (state.getBank().isOpen()) {
-            if (state.getInventory().has(barItem(), oreItem())) {
+            if (state.getInventory().has(barItem()) || (coalRun && state.getInventory().has(oreItem()))) {
                 return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
             }
 
             if (state.getFurnace().has(oreItem()) && state.getFurnace().has(barItem())) {
+                if (state.getInventory().has(barItem(), oreItem())) {
+                    return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
+                }
                 return collectBars;
             }
 
@@ -86,6 +73,23 @@ abstract public class MetalBarMethod extends Method
                 return withdrawOre();
             }
         }
+
+        if (state.getInventory().has(ItemID.COAL) || (state.getInventory().has(oreItem()) && !coalRun)) {
+            return putOntoConveyorBelt;
+        }
+
+        if (state.getPlayer().isAtConveyorBelt() &&
+            !state.getCoalBag().isEmpty()) {
+            return emptyCoalBag;
+        }
+
+        if (!tickPerfectMethod && oreOnConveyor) {
+            return waitForBars;
+        }
+
+		if ((furnaceHasOre && furnaceHasBar) || (furnaceHasBar && (!tickPerfectMethod || oreOnConveyor))) {
+			return collectBars;
+		}
 
         return openBank;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -70,6 +70,10 @@ abstract public class MetalBarMethod extends Method
                 return state.getConfig().useDepositInventory() ? depositInventory : depositBarsAndOres;
             }
 
+            if (state.getFurnace().has(oreItem()) && state.getFurnace().has(barItem())) {
+                return collectBars;
+            }
+
             if (state.getCoalBag().isEmpty()) {
                 return fillCoalBag;
             }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -45,7 +45,7 @@ abstract public class MetalBarMethod extends Method
         if (prerequisite != null) return prerequisite;
         boolean coalRun = state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - state.getFurnace().getCoalOffset());
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();
-        boolean furnaceHasBar = state.getFurnace().has(barItem());
+        boolean furnaceHasBars = state.getFurnace().has(barItem()) && state.getFurnace().getQuantity(barItem()) >= state.getInventory().getFreeSlotsIncludingOresAndBars();
         boolean tickPerfectMethod = state.getConfig().tickPerfectMethod();
 
         if (state.getInventory().has(ItemID.COAL) || (state.getInventory().has(oreItem()) && !coalRun)) {
@@ -61,7 +61,7 @@ abstract public class MetalBarMethod extends Method
             return waitForBars;
         }
 
-		if (furnaceHasBar && (!tickPerfectMethod || oreOnConveyor)) {
+		if (furnaceHasBars && (!tickPerfectMethod || oreOnConveyor)) {
 			return collectBars;
 		}
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MetalBarMethod.java
@@ -14,13 +14,13 @@ abstract public class MetalBarMethod extends Method
 {
     public abstract int oreItem();
 
-    protected abstract MethodStep withdrawOre();
+    protected abstract MethodStep[] withdrawOre();
 
     protected abstract int barItem();
 
     protected abstract int coalPer();
 
-    private MethodStep checkPrerequisite(BlastFurnaceState state)
+    private MethodStep[] checkPrerequisite(BlastFurnaceState state)
     {
         if (!state.getInventory().has(ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG)) {
             return state.getBank().isOpen() ? withdrawCoalBag : openBank;
@@ -39,9 +39,9 @@ abstract public class MetalBarMethod extends Method
     }
 
     @Override
-    public MethodStep next(BlastFurnaceState state)
+    public MethodStep[] next(BlastFurnaceState state)
     {
-        MethodStep prerequisite = checkPrerequisite(state);
+        MethodStep[] prerequisite = checkPrerequisite(state);
         if (prerequisite != null) return prerequisite;
         boolean coalRun = state.getFurnace().getQuantity(ItemID.COAL) < 27 * (coalPer() - state.getFurnace().getCoalOffset());
         boolean oreOnConveyor = state.getPlayer().hasOreOnConveyor();

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -31,13 +31,13 @@ public abstract class Method
     protected final MethodStep[] withdrawMaxCape = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_MAX_CAPE, ItemID.MAX_CAPE) };
     protected final MethodStep[] equipSmithingCape = new MethodStep[] { new ItemStep(Strings.EQUIP_SMITHING_CAPE, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) };
     protected final MethodStep[] equipMaxCape = new MethodStep[] { new ItemStep(Strings.EQUIP_MAX_CAPE, ItemID.MAX_CAPE) };
-    protected final MethodStep[] depositBarsAndOres = new MethodStep[] { new ItemStep(Strings.DEPOSIT_BARS_AND_ORES, BarsOres.getAllIds()) };
+    protected final MethodStep[] depositBarsAndOres = new MethodStep[] { new ItemStep(Strings.DEPOSIT_BARS_AND_ORES, BarsOres.getAllIds()), new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
     protected final MethodStep[] depositStaminaPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_STAMINA_POTIONS, ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3, ItemID.STAMINA_POTION4) };
     protected final MethodStep[] depositSuperEnergyPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_SUPER_ENERGY_POTIONS, ItemID.VIAL, ItemID.SUPER_ENERGY1, ItemID.SUPER_ENERGY2, ItemID.SUPER_ENERGY3, ItemID.SUPER_ENERGY4) };
     protected final MethodStep[] depositEnergyPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_ENERGY_POTIONS, ItemID.VIAL, ItemID.ENERGY_POTION1, ItemID.ENERGY_POTION2, ItemID.ENERGY_POTION3, ItemID.ENERGY_POTION4) };
 
     // objects
-    protected final MethodStep[] depositInventory = new MethodStep[] { new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY) };
+    protected final MethodStep[] depositInventory = new MethodStep[] { new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY), new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
     protected final MethodStep[] putOntoConveyorBelt = new MethodStep[] { new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
     protected final MethodStep[] putOntoConveyorBeltAndEquipGoldsmithGauntlets = new MethodStep[] { new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS), new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
     protected final MethodStep[] openBank = new MethodStep[] { new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -40,7 +40,7 @@ public abstract class Method
     protected final MethodStep[] depositInventory = new MethodStep[] { new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY) };
     protected final MethodStep[] putOntoConveyorBelt = new MethodStep[] { new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
     protected final MethodStep[] openBank = new MethodStep[] { new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
-    protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER) };
     protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION) };
 
     public abstract MethodStep[] next(BlastFurnaceState state);

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -43,6 +43,9 @@ public abstract class Method
     protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER) };
     protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION) };
 
+    protected final MethodStep[] goToDispenserAndEquipIceOrSmithsGloves = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] collectBarsAndEquipGoldsmithGauntlets = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+
     public abstract MethodStep[] next(BlastFurnaceState state);
 
     public abstract String getName();

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -11,39 +11,39 @@ import net.runelite.api.widgets.WidgetInfo;
 public abstract class Method
 {
     // items
-    protected final MethodStep fillCoalBag = new ItemStep(Strings.FILL_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG);
-    protected final MethodStep refillCoalBag = new ItemStep(Strings.REFILL_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG);
-    protected final MethodStep emptyCoalBag = new ItemStep(Strings.EMPTY_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG);
-    protected final MethodStep withdrawCoalBag = new BankItemStep(Strings.WITHDRAW_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG);
+    protected final MethodStep[] fillCoalBag = new MethodStep[] { new ItemStep(Strings.FILL_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG) };
+    protected final MethodStep[] refillCoalBag = new MethodStep[] { new ItemStep(Strings.REFILL_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG) };
+    protected final MethodStep[] emptyCoalBag = new MethodStep[] { new ItemStep(Strings.EMPTY_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG) };
+    protected final MethodStep[] withdrawCoalBag = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_COAL_BAG, ItemID.COAL_BAG_12019, ItemID.OPEN_COAL_BAG) };
 
-    protected final MethodStep withdrawCoal = new BankItemStep(Strings.WITHDRAW_COAL, ItemID.COAL);
-    protected final MethodStep withdrawGoldOre = new BankItemStep(Strings.WITHDRAW_GOLD_ORE, ItemID.GOLD_ORE);
-    protected final MethodStep withdrawIronOre = new BankItemStep(Strings.WITHDRAW_IRON_ORE, ItemID.IRON_ORE);
-    protected final MethodStep withdrawMithrilOre = new BankItemStep(Strings.WITHDRAW_MITHRIL_ORE, ItemID.MITHRIL_ORE);
-    protected final MethodStep withdrawAdamantiteOre = new BankItemStep(Strings.WITHDRAW_ADAMANTITE_ORE, ItemID.ADAMANTITE_ORE);
-    protected final MethodStep withdrawRuniteOre = new BankItemStep(Strings.WITHDRAW_RUNITE_ORE, ItemID.RUNITE_ORE);
+    protected final MethodStep[] withdrawCoal = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_COAL, ItemID.COAL) };
+    protected final MethodStep[] withdrawGoldOre = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_GOLD_ORE, ItemID.GOLD_ORE) };
+    protected final MethodStep[] withdrawIronOre = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_IRON_ORE, ItemID.IRON_ORE) };
+    protected final MethodStep[] withdrawMithrilOre = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_MITHRIL_ORE, ItemID.MITHRIL_ORE) };
+    protected final MethodStep[] withdrawAdamantiteOre = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ADAMANTITE_ORE, ItemID.ADAMANTITE_ORE) };
+    protected final MethodStep[] withdrawRuniteOre = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_RUNITE_ORE, ItemID.RUNITE_ORE) };
 
-    protected final MethodStep withdrawIceOrSmithsGloves = new BankItemStep(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
-    protected final MethodStep equipIceOrSmithsGloves = new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I);
-    protected final MethodStep withdrawGoldsmithGauntlets = new BankItemStep(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS);
-    protected final MethodStep equipGoldsmithGauntlets = new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS);
-    protected final MethodStep withdrawSmithingCape = new BankItemStep(Strings.WITHDRAW_SMITHING_CAPE, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET);
-    protected final MethodStep withdrawMaxCape = new BankItemStep(Strings.WITHDRAW_MAX_CAPE, ItemID.MAX_CAPE);
-    protected final MethodStep equipSmithingCape = new ItemStep(Strings.EQUIP_SMITHING_CAPE, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET);
-    protected final MethodStep equipMaxCape = new ItemStep(Strings.EQUIP_MAX_CAPE, ItemID.MAX_CAPE);
-    protected final MethodStep depositBarsAndOres = new ItemStep(Strings.DEPOSIT_BARS_AND_ORES, BarsOres.getAllIds());
-    protected final MethodStep depositStaminaPotions = new ItemStep(Strings.DEPOSIT_STAMINA_POTIONS, ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3, ItemID.STAMINA_POTION4);
-    protected final MethodStep depositSuperEnergyPotions = new ItemStep(Strings.DEPOSIT_SUPER_ENERGY_POTIONS, ItemID.VIAL, ItemID.SUPER_ENERGY1, ItemID.SUPER_ENERGY2, ItemID.SUPER_ENERGY3, ItemID.SUPER_ENERGY4);
-    protected final MethodStep depositEnergyPotions = new ItemStep(Strings.DEPOSIT_ENERGY_POTIONS, ItemID.VIAL, ItemID.ENERGY_POTION1, ItemID.ENERGY_POTION2, ItemID.ENERGY_POTION3, ItemID.ENERGY_POTION4);
+    protected final MethodStep[] withdrawIceOrSmithsGloves = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] equipIceOrSmithsGloves = new MethodStep[] { new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] withdrawGoldsmithGauntlets = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS) };
+    protected final MethodStep[] equipGoldsmithGauntlets = new MethodStep[] { new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS) };
+    protected final MethodStep[] withdrawSmithingCape = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_SMITHING_CAPE, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) };
+    protected final MethodStep[] withdrawMaxCape = new MethodStep[] { new BankItemStep(Strings.WITHDRAW_MAX_CAPE, ItemID.MAX_CAPE) };
+    protected final MethodStep[] equipSmithingCape = new MethodStep[] { new ItemStep(Strings.EQUIP_SMITHING_CAPE, ItemID.SMITHING_CAPE, ItemID.SMITHING_CAPET) };
+    protected final MethodStep[] equipMaxCape = new MethodStep[] { new ItemStep(Strings.EQUIP_MAX_CAPE, ItemID.MAX_CAPE) };
+    protected final MethodStep[] depositBarsAndOres = new MethodStep[] { new ItemStep(Strings.DEPOSIT_BARS_AND_ORES, BarsOres.getAllIds()) };
+    protected final MethodStep[] depositStaminaPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_STAMINA_POTIONS, ItemID.VIAL, ItemID.STAMINA_POTION1, ItemID.STAMINA_POTION2, ItemID.STAMINA_POTION3, ItemID.STAMINA_POTION4) };
+    protected final MethodStep[] depositSuperEnergyPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_SUPER_ENERGY_POTIONS, ItemID.VIAL, ItemID.SUPER_ENERGY1, ItemID.SUPER_ENERGY2, ItemID.SUPER_ENERGY3, ItemID.SUPER_ENERGY4) };
+    protected final MethodStep[] depositEnergyPotions = new MethodStep[] { new ItemStep(Strings.DEPOSIT_ENERGY_POTIONS, ItemID.VIAL, ItemID.ENERGY_POTION1, ItemID.ENERGY_POTION2, ItemID.ENERGY_POTION3, ItemID.ENERGY_POTION4) };
 
     // objects
-    protected final MethodStep depositInventory = new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY);
-    protected final MethodStep putOntoConveyorBelt = new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT);
-    protected final MethodStep openBank = new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST);
-    protected final MethodStep collectBars = new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER);
-    protected final MethodStep waitForBars = new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION);
+    protected final MethodStep[] depositInventory = new MethodStep[] { new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY) };
+    protected final MethodStep[] putOntoConveyorBelt = new MethodStep[] { new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
+    protected final MethodStep[] openBank = new MethodStep[] { new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
+    protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION) };
 
-    public abstract MethodStep next(BlastFurnaceState state);
+    public abstract MethodStep[] next(BlastFurnaceState state);
 
     public abstract String getName();
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -42,7 +42,7 @@ public abstract class Method
     protected final MethodStep[] putOntoConveyorBeltAndEquipGoldsmithGauntlets = new MethodStep[] { new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS), new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
     protected final MethodStep[] openBank = new MethodStep[] { new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
     protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I), new TileStep("", EasyBlastFurnacePlugin.PICKUP_POSITION) };
-    protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION) };
     protected final MethodStep[] waitForGoldBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS) };
     protected final MethodStep[] goToDispenser = new MethodStep[] { new TileStep(Strings.GO_TO_DISPENSER, EasyBlastFurnacePlugin.PICKUP_POSITION) };
     protected final MethodStep[] goToDispenserAndEquipIceOrSmithsGloves = new MethodStep[] { new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I), new TileStep(Strings.GO_TO_DISPENSER, EasyBlastFurnacePlugin.PICKUP_POSITION) };

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/Method.java
@@ -39,12 +39,14 @@ public abstract class Method
     // objects
     protected final MethodStep[] depositInventory = new MethodStep[] { new WidgetStep(Strings.DEPOSIT_INVENTORY, WidgetInfo.BANK_DEPOSIT_INVENTORY) };
     protected final MethodStep[] putOntoConveyorBelt = new MethodStep[] { new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
+    protected final MethodStep[] putOntoConveyorBeltAndEquipGoldsmithGauntlets = new MethodStep[] { new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS), new ObjectStep(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, EasyBlastFurnacePlugin.CONVEYOR_BELT) };
     protected final MethodStep[] openBank = new MethodStep[] { new ObjectStep(Strings.OPEN_BANK, EasyBlastFurnacePlugin.BANK_CHEST) };
-    protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER) };
-    protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION) };
-
-    protected final MethodStep[] goToDispenserAndEquipIceOrSmithsGloves = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
-    protected final MethodStep[] collectBarsAndEquipGoldsmithGauntlets = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] collectBars = new MethodStep[] { new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I), new TileStep("", EasyBlastFurnacePlugin.PICKUP_POSITION) };
+    protected final MethodStep[] waitForBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I) };
+    protected final MethodStep[] waitForGoldBars = new MethodStep[] { new TileStep(Strings.WAIT_FOR_BARS, EasyBlastFurnacePlugin.PICKUP_POSITION), new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS, ItemID.GOLDSMITH_GAUNTLETS) };
+    protected final MethodStep[] goToDispenser = new MethodStep[] { new TileStep(Strings.GO_TO_DISPENSER, EasyBlastFurnacePlugin.PICKUP_POSITION) };
+    protected final MethodStep[] goToDispenserAndEquipIceOrSmithsGloves = new MethodStep[] { new ItemStep(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, ItemID.ICE_GLOVES, ItemID.SMITHS_GLOVES_I), new TileStep(Strings.GO_TO_DISPENSER, EasyBlastFurnacePlugin.PICKUP_POSITION) };
+    protected final MethodStep[] collectBarsAndEquipGoldsmithGauntlets = new MethodStep[] { new ItemStep(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS, ItemID.GOLDSMITH_GAUNTLETS), new ObjectStep(Strings.COLLECT_BARS, EasyBlastFurnacePlugin.BAR_DISPENSER) };
 
     public abstract MethodStep[] next(BlastFurnaceState state);
 

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MithrilBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MithrilBarMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class MithrilBarMethod extends MetalBarMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawMithrilOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/MithrilHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/MithrilHybridMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class MithrilHybridMethod extends GoldHybridMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawMithrilOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/RuniteBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/RuniteBarMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class RuniteBarMethod extends MetalBarMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawRuniteOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/RuniteHybridMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/RuniteHybridMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class RuniteHybridMethod extends GoldHybridMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawRuniteOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/methods/SteelBarMethod.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/methods/SteelBarMethod.java
@@ -8,7 +8,7 @@ import net.runelite.api.ItemID;
 public class SteelBarMethod extends MetalBarMethod
 {
     @Override
-    protected MethodStep withdrawOre()
+    protected MethodStep[] withdrawOre()
     {
         return withdrawIronOre;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/BankItemStepOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/BankItemStepOverlay.java
@@ -44,48 +44,50 @@ public class BankItemStepOverlay extends WidgetItemOverlay
     {
         if (config.itemOverlayMode() == ItemOverlaySetting.NONE) return;
 
-        MethodStep step = methodHandler.getStep();
+        MethodStep[] steps = methodHandler.getSteps();
+        if (steps == null) return;
 
-        if (step == null) return;
-        if (!(step instanceof BankItemStep)) return;
-        if (Arrays.stream(((BankItemStep) step).getItemIds()).noneMatch(id -> id == itemId)) return;
+        for (MethodStep step : steps) {
+            if (!(step instanceof BankItemStep)) continue;
+            if (Arrays.stream(((BankItemStep) step).getItemIds()).noneMatch(id -> id == itemId)) continue;
 
-        Color color = config.itemOverlayColor();
+            Color color = config.itemOverlayColor();
 
-        Rectangle bounds = widgetItem.getCanvasBounds();
+            Rectangle bounds = widgetItem.getCanvasBounds();
 
-        if (config.itemOverlayMode() == ItemOverlaySetting.OUTLINE) {
-            BufferedImage outline = itemManager.getItemOutline(itemId, widgetItem.getQuantity(), color);
-            ImageComponent imageComponent = new ImageComponent(outline);
-            imageComponent.setPreferredLocation(new Point(bounds.x, bounds.y));
-            imageComponent.render(graphics);
-        } else {
-            graphics.setColor(color);
-            graphics.draw(bounds);
+            if (config.itemOverlayMode() == ItemOverlaySetting.OUTLINE) {
+                BufferedImage outline = itemManager.getItemOutline(itemId, widgetItem.getQuantity(), color);
+                ImageComponent imageComponent = new ImageComponent(outline);
+                imageComponent.setPreferredLocation(new Point(bounds.x, bounds.y));
+                imageComponent.render(graphics);
+            } else {
+                graphics.setColor(color);
+                graphics.draw(bounds);
+            }
+
+            if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.NONE) continue;
+
+            TextComponent textComponent = new TextComponent();
+            textComponent.setColor(color);
+            textComponent.setText(step.getTooltip());
+
+            FontMetrics fontMetrics = graphics.getFontMetrics();
+            int textWidth = fontMetrics.stringWidth(step.getTooltip());
+            int textHeight = fontMetrics.getHeight();
+
+            if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.BELOW) {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y + bounds.height + textHeight
+                ));
+            } else {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y - textHeight / 2
+                ));
+            }
+
+            textComponent.render(graphics);
         }
-
-        if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.NONE) return;
-
-        TextComponent textComponent = new TextComponent();
-        textComponent.setColor(color);
-        textComponent.setText(step.getTooltip());
-
-        FontMetrics fontMetrics = graphics.getFontMetrics();
-        int textWidth = fontMetrics.stringWidth(step.getTooltip());
-        int textHeight = fontMetrics.getHeight();
-
-        if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.BELOW) {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y + bounds.height + textHeight
-            ));
-        } else {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y - textHeight / 2
-            ));
-        }
-
-        textComponent.render(graphics);
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/InstructionOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/InstructionOverlay.java
@@ -52,18 +52,20 @@ public class InstructionOverlay extends OverlayPanel
         if (!config.showStepOverlay()) return null;
 
         Method method = methodHandler.getMethod();
-        MethodStep step = methodHandler.getStep();
+        MethodStep[] steps = methodHandler.getSteps();
 
-        String methodName = method != null ? method.getName() : "No method selected";
-        String tooltip = state.getPlayer().isOnBlastFurnaceWorld()
-            ? (step != null
-            ? step.getTooltip()
-            : "Withdraw an ore from the bank to start. You can start a hybrid method by also withdrawing gold ore.")
-            : "You need to be on a Blast Furnace themed world to use this plugin.";
+        for (MethodStep step : steps) {
+            String methodName = method != null ? method.getName() : "No method selected";
+            String tooltip = state.getPlayer().isOnBlastFurnaceWorld()
+                    ? (step != null
+                    ? step.getTooltip()
+                    : "Withdraw an ore from the bank to start. You can start a hybrid method by also withdrawing gold ore.")
+                    : "You need to be on a Blast Furnace themed world to use this plugin.";
 
-        panelComponent.getChildren().add(TitleComponent.builder().text("Easy Blast Furnace").build());
-        panelComponent.getChildren().add(LineComponent.builder().left(methodName).leftColor(config.itemOverlayColor()).build());
-        panelComponent.getChildren().add(LineComponent.builder().left(tooltip).leftColor(TOOLTIP_COLOR).build());
+            panelComponent.getChildren().add(TitleComponent.builder().text("Easy Blast Furnace").build());
+            panelComponent.getChildren().add(LineComponent.builder().left(methodName).leftColor(config.itemOverlayColor()).build());
+            panelComponent.getChildren().add(LineComponent.builder().left(tooltip).leftColor(TOOLTIP_COLOR).build());
+        }
 
         return super.render(graphics);
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/InstructionOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/InstructionOverlay.java
@@ -53,6 +53,9 @@ public class InstructionOverlay extends OverlayPanel
 
         Method method = methodHandler.getMethod();
         MethodStep[] steps = methodHandler.getSteps();
+        int index = 0;
+
+        if (steps == null) return null;
 
         for (MethodStep step : steps) {
             String methodName = method != null ? method.getName() : "No method selected";
@@ -62,8 +65,12 @@ public class InstructionOverlay extends OverlayPanel
                     : "Withdraw an ore from the bank to start. You can start a hybrid method by also withdrawing gold ore.")
                     : "You need to be on a Blast Furnace themed world to use this plugin.";
 
-            panelComponent.getChildren().add(TitleComponent.builder().text("Easy Blast Furnace").build());
-            panelComponent.getChildren().add(LineComponent.builder().left(methodName).leftColor(config.itemOverlayColor()).build());
+            if (index == 0) {
+                panelComponent.getChildren().add(TitleComponent.builder().text("Easy Blast Furnace").build());
+                panelComponent.getChildren().add(LineComponent.builder().left(methodName).leftColor(config.itemOverlayColor()).build());
+            }
+
+            index++;
             panelComponent.getChildren().add(LineComponent.builder().left(tooltip).leftColor(TOOLTIP_COLOR).build());
         }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/ObjectStepOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/ObjectStepOverlay.java
@@ -38,48 +38,51 @@ public class ObjectStepOverlay extends Overlay
     {
         if (!config.showObjectOverlays()) return null;
 
-        MethodStep step = methodHandler.getStep();
+        MethodStep[] steps = methodHandler.getSteps();
 
-        if (step == null) return null;
-        if (!(step instanceof ObjectStep)) return null;
+        if (steps == null) return null;
 
-        Color color = config.objectOverlayColor();
+        for (MethodStep step : steps) {
+            if (!(step instanceof ObjectStep)) continue;
 
-        GameObject object = objectManager.get(((ObjectStep) step).getObjectId());
-        Shape clickBox = object.getClickbox();
+            Color color = config.objectOverlayColor();
 
-        if (clickBox == null) return null;
+            GameObject object = objectManager.get(((ObjectStep) step).getObjectId());
+            Shape clickBox = object.getClickbox();
 
-        graphics.setColor(color);
-        graphics.draw(clickBox);
-        graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
-        graphics.fill(clickBox);
+            if (clickBox == null) continue;
 
-        if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.NONE) return null;
+            graphics.setColor(color);
+            graphics.draw(clickBox);
+            graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
+            graphics.fill(clickBox);
 
-        TextComponent textComponent = new TextComponent();
-        Rectangle bounds = object.getClickbox().getBounds();
+            if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.NONE) continue;
 
-        FontMetrics fontMetrics = graphics.getFontMetrics();
-        int textWidth = fontMetrics.stringWidth(step.getTooltip());
-        int textHeight = fontMetrics.getHeight();
+            TextComponent textComponent = new TextComponent();
+            Rectangle bounds = object.getClickbox().getBounds();
 
-        if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.ABOVE) {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y - textHeight
-            ));
-        } else {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y + bounds.height
-            ));
+            FontMetrics fontMetrics = graphics.getFontMetrics();
+            int textWidth = fontMetrics.stringWidth(step.getTooltip());
+            int textHeight = fontMetrics.getHeight();
+
+            if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.ABOVE) {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y - textHeight
+                ));
+            } else {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y + bounds.height
+                ));
+            }
+
+            textComponent.setColor(color);
+            textComponent.setText(step.getTooltip());
+
+            textComponent.render(graphics);
         }
-
-        textComponent.setColor(color);
-        textComponent.setText(step.getTooltip());
-
-        textComponent.render(graphics);
 
         return null;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/TileStepOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/TileStepOverlay.java
@@ -36,48 +36,51 @@ public class TileStepOverlay extends Overlay
     {
         if (!config.showObjectOverlays()) return null;
 
-        MethodStep step = methodHandler.getStep();
+        MethodStep[] steps = methodHandler.getSteps();
 
-        if (step == null) return null;
-        if (!(step instanceof TileStep)) return null;
+        if (steps == null) return null;
 
-        Color color = config.objectOverlayColor();
+        for (MethodStep step : steps) {
+            if (!(step instanceof TileStep)) continue;
 
-        LocalPoint localPoint = LocalPoint.fromWorld(client, ((TileStep) step).getWorldPoint());
-        if (localPoint == null) return null;
+            Color color = config.objectOverlayColor();
 
-        Polygon polygon = Perspective.getCanvasTilePoly(client, localPoint);
+            LocalPoint localPoint = LocalPoint.fromWorld(client, ((TileStep) step).getWorldPoint());
+            if (localPoint == null) continue;
 
-        graphics.setColor(color);
-        graphics.draw(polygon);
-        graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
-        graphics.fill(polygon);
+            Polygon polygon = Perspective.getCanvasTilePoly(client, localPoint);
 
-        if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.NONE) return null;
+            graphics.setColor(color);
+            graphics.draw(polygon);
+            graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
+            graphics.fill(polygon);
 
-        TextComponent textComponent = new TextComponent();
-        Rectangle bounds = polygon.getBounds();
+            if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.NONE) continue;
 
-        FontMetrics fontMetrics = graphics.getFontMetrics();
-        int textWidth = fontMetrics.stringWidth(step.getTooltip());
-        int textHeight = fontMetrics.getHeight();
+            TextComponent textComponent = new TextComponent();
+            Rectangle bounds = polygon.getBounds();
 
-        if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.ABOVE) {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y - textHeight
-            ));
-        } else {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y + bounds.height
-            ));
+            FontMetrics fontMetrics = graphics.getFontMetrics();
+            int textWidth = fontMetrics.stringWidth(step.getTooltip());
+            int textHeight = fontMetrics.getHeight();
+
+            if (config.objectOverlayTextMode() == HighlightOverlayTextSetting.ABOVE) {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y - textHeight
+                ));
+            } else {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y + bounds.height
+                ));
+            }
+
+            textComponent.setColor(color);
+            textComponent.setText(step.getTooltip());
+
+            textComponent.render(graphics);
         }
-
-        textComponent.setColor(color);
-        textComponent.setText(step.getTooltip());
-
-        textComponent.render(graphics);
 
         return null;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/overlays/WidgetStepOverlay.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/overlays/WidgetStepOverlay.java
@@ -42,46 +42,49 @@ public class WidgetStepOverlay extends Overlay
     {
         if (config.itemOverlayMode() == ItemOverlaySetting.NONE) return null;
 
-        MethodStep step = methodHandler.getStep();
+        MethodStep[] steps = methodHandler.getSteps();
 
-        if (step == null) return null;
-        if (!(step instanceof WidgetStep)) return null;
+        if (steps == null) return null;
 
-        Widget widget = client.getWidget(((WidgetStep) step).getWidgetInfo());
-        if (widget == null) return null;
+        for (MethodStep step : steps) {
+            if (!(step instanceof WidgetStep)) continue;
+
+            Widget widget = client.getWidget(((WidgetStep) step).getWidgetInfo());
+            if (widget == null) continue;
 
 
-        Color color = config.itemOverlayColor();
-        Rectangle bounds = widget.getBounds();
+            Color color = config.itemOverlayColor();
+            Rectangle bounds = widget.getBounds();
 
-        graphics.setColor(color);
-        graphics.draw(bounds);
-        graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
-        graphics.fill(bounds);
+            graphics.setColor(color);
+            graphics.draw(bounds);
+            graphics.setColor(new Color(color.getRed(), color.getBlue(), color.getGreen(), 20));
+            graphics.fill(bounds);
 
-        if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.NONE) return null;
+            if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.NONE) continue;
 
-        TextComponent textComponent = new TextComponent();
-        textComponent.setColor(config.itemOverlayColor());
-        textComponent.setText(step.getTooltip());
+            TextComponent textComponent = new TextComponent();
+            textComponent.setColor(config.itemOverlayColor());
+            textComponent.setText(step.getTooltip());
 
-        FontMetrics fontMetrics = graphics.getFontMetrics();
-        int textWidth = fontMetrics.stringWidth(step.getTooltip());
-        int textHeight = fontMetrics.getHeight();
+            FontMetrics fontMetrics = graphics.getFontMetrics();
+            int textWidth = fontMetrics.stringWidth(step.getTooltip());
+            int textHeight = fontMetrics.getHeight();
 
-        if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.BELOW) {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y + bounds.height + textHeight
-            ));
-        } else {
-            textComponent.setPosition(new Point(
-                bounds.x + bounds.width / 2 - textWidth / 2,
-                bounds.y - textHeight / 2
-            ));
+            if (config.itemOverlayTextMode() == HighlightOverlayTextSetting.BELOW) {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y + bounds.height + textHeight
+                ));
+            } else {
+                textComponent.setPosition(new Point(
+                        bounds.x + bounds.width / 2 - textWidth / 2,
+                        bounds.y - textHeight / 2
+                ));
+            }
+
+            textComponent.render(graphics);
         }
-
-        textComponent.render(graphics);
 
         return null;
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -2,6 +2,7 @@ package com.toofifty.easyblastfurnace.state;
 
 import com.toofifty.easyblastfurnace.EasyBlastFurnaceConfig;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 
 import javax.inject.Inject;
@@ -9,6 +10,7 @@ import javax.inject.Singleton;
 
 @Getter
 @Singleton
+@Slf4j
 public class BlastFurnaceState
 {
     @Inject
@@ -32,12 +34,18 @@ public class BlastFurnaceState
     @Inject
     private EasyBlastFurnaceConfig config;
 
+    private int lastPositiveChange = 0;
     public void update()
     {
         int invChange = inventory.getChange(ItemID.GOLD_ORE, ItemID.IRON_ORE, ItemID.MITHRIL_ORE, ItemID.ADAMANTITE_ORE, ItemID.RUNITE_ORE);
 
-        if (player.isAtConveyorBelt() && invChange < 0) {
-            furnace.setOresOnConveyorBelt(-invChange);
+        if (invChange > 0) {
+            lastPositiveChange = invChange;
+        }
+
+        if (player.isAtConveyorBelt() && invChange == -1) { // invChange is always -1 when adding ores to the conveyor belt.
+            furnace.setOresOnConveyorBelt(lastPositiveChange);
+            lastPositiveChange = 0;
             player.hasOreOnConveyor(true);
         }
 
@@ -49,5 +57,8 @@ public class BlastFurnaceState
 
         inventory.update();
         furnace.update();
+        log.info("Gold ore in furnace: " + furnace.getQuantity(ItemID.GOLD_ORE));
+        log.info("coal in furnace: " + furnace.getQuantity(ItemID.COAL));
+        log.info("adamantite ore in furnace: " + furnace.getQuantity(ItemID.ADAMANTITE_ORE));
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -57,8 +57,5 @@ public class BlastFurnaceState
 
         inventory.update();
         furnace.update();
-        log.info("Gold ore in furnace: " + furnace.getQuantity(ItemID.GOLD_ORE));
-        log.info("coal in furnace: " + furnace.getQuantity(ItemID.COAL));
-        log.info("adamantite ore in furnace: " + furnace.getQuantity(ItemID.ADAMANTITE_ORE));
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/BlastFurnaceState.java
@@ -47,10 +47,6 @@ public class BlastFurnaceState
             coalBag.setMaxCoal(27);
         }
 
-        if (coalBag.getCoalOntoConveyorCount() > 0 && bank.isOpen() && inventory.hasChanged(ItemID.COAL) && inventory.has(ItemID.COAL)) {
-            coalBag.coalOntoConveyor(0);
-        }
-
         inventory.update();
         furnace.update();
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -21,9 +21,6 @@ public class CoalBagState
     @Getter
     private int maxCoal = 27;
 
-    @Getter
-    private int coalOntoConveyorCount = 0;
-
     public void setMaxCoal(int quantity)
     {
         maxCoal = quantity;
@@ -60,16 +57,6 @@ public class CoalBagState
             setCoal(maxCoal);
             return;
         }
-        coalOntoConveyorCount = 0;
-        setCoal(coal + inventory.getQuantity(ItemID.COAL));
-    }
-
-    public void coalOntoConveyor(int ...override)
-    {
-        if (override.length > 0) {
-            coalOntoConveyorCount = override[0];
-        } else {
-            coalOntoConveyorCount++;
-        }
+        setCoal(Math.min(coal + inventory.getQuantity(ItemID.COAL), maxCoal));
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -57,6 +57,6 @@ public class CoalBagState
             setCoal(maxCoal);
             return;
         }
-        setCoal(Math.min(coal + inventory.getQuantity(ItemID.COAL), maxCoal));
+        setCoal(coal + inventory.getQuantity(ItemID.COAL));
     }
 }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -10,6 +10,9 @@ public class CoalBagState
     private static final int MIN_COAL = 0;
 
     @Inject
+    private Client client;
+
+    @Inject
     private InventoryState inventory;
 
     @Inject
@@ -20,6 +23,8 @@ public class CoalBagState
 
     @Getter
     private int maxCoal = 27;
+
+    public boolean recentlyEmptiedCoalBag = false;
 
     public void setMaxCoal(int quantity)
     {
@@ -47,7 +52,7 @@ public class CoalBagState
             setCoal(MIN_COAL);
             return;
         }
-
+        recentlyEmptiedCoalBag = true;
         setCoal(coal - inventory.getFreeSlots());
     }
 

--- a/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/CoalBagState.java
@@ -10,9 +10,6 @@ public class CoalBagState
     private static final int MIN_COAL = 0;
 
     @Inject
-    private Client client;
-
-    @Inject
     private InventoryState inventory;
 
     @Inject

--- a/src/main/java/com/toofifty/easyblastfurnace/state/FurnaceState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/FurnaceState.java
@@ -62,11 +62,13 @@ public class FurnaceState
         return total;
     }
 
-    public boolean has(int ...itemIds) {
+    public boolean has(int ...itemIds)
+    {
         return getQuantity(itemIds) > 0;
     }
 
-    public boolean isCoalRunNext(int coalPer) {
+    public boolean isCoalRunNext(int coalPer)
+    {
         int coalInFurnace = getQuantity(ItemID.COAL);
         return coalInFurnace < 27 * (coalPer - getCoalOffset());
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 public class PlayerState
 {
     private static final WorldPoint LOAD_POSITION = new WorldPoint(1942, 4967, 0);
-    private static final WorldPoint COLLECT_POSITION = new WorldPoint(1940, 4963, 0);
+    private static final WorldPoint COLLECT_POSITION = new WorldPoint(1940, 4962, 0);
     private static final int[] BLAST_FURNACE_WORLDS = new int[]{
         352, 355, 356, 357, 358, 386, 387, 395, 424, 466, 494, 495, 496, 515, 516
     };

--- a/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/state/PlayerState.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 public class PlayerState
 {
     private static final WorldPoint LOAD_POSITION = new WorldPoint(1942, 4967, 0);
+    private static final WorldPoint COLLECT_POSITION = new WorldPoint(1940, 4963, 0);
     private static final int[] BLAST_FURNACE_WORLDS = new int[]{
         352, 355, 356, 357, 358, 386, 387, 395, 424, 466, 494, 495, 496, 515, 516
     };
@@ -46,6 +47,15 @@ public class PlayerState
 
         WorldPoint location = player.getWorldLocation();
         return location.distanceTo(LOAD_POSITION) < 2;
+    }
+
+    public boolean isAtBarDispenser()
+    {
+        Player player = client.getLocalPlayer();
+        assert player != null;
+
+        WorldPoint location = player.getWorldLocation();
+        return location.distanceTo(COLLECT_POSITION) < 2;
     }
 
     public boolean hasEnoughEnergy()

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/MethodHandler.java
@@ -26,7 +26,7 @@ public class MethodHandler
     private Method method;
 
     @Getter
-    private MethodStep step;
+    private MethodStep[] steps;
 
     public void next()
     {
@@ -34,14 +34,14 @@ public class MethodHandler
         if (!state.getPlayer().isOnBlastFurnaceWorld()) return;
         ItemStepOverlay.currentWidgetItem = null;
 
-        step = drinkPotionMethod.next(state);
-        if (step == null) step = method.next(state);
+        steps = drinkPotionMethod.next(state);
+        if (steps == null) steps = method.next(state);
     }
 
     public void clear()
     {
         method = null;
-        step = null;
+        steps = null;
     }
 
     private boolean inInventory(int itemId)

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/SessionStatistics.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/SessionStatistics.java
@@ -168,17 +168,25 @@ public class SessionStatistics
             ItemID.GOLD_BAR, ItemID.STEEL_BAR, ItemID.MITHRIL_BAR, ItemID.ADAMANTITE_BAR, ItemID.RUNITE_BAR
         };
 
-        for (int barId : bars) {
-            int diff = state.getFurnace().getChange(barId);
+        int[] ores = new int[]{
+            ItemID.GOLD_ORE, ItemID.IRON_ORE, ItemID.MITHRIL_ORE, ItemID.ADAMANTITE_ORE, ItemID.RUNITE_ORE
+        };
+
+        for (int oreId : ores) {
+            int diff = state.getFurnace().getChange(oreId);
             if (diff > 0) {
-                log.info("Diff: " + diff + " | oresOnConveyorBelt: " + state.getFurnace().getOresOnConveyorBelt());
-                int totalBars = outputs.getOrDefault(barId, 0) + diff;
-                outputs.put(barId, totalBars);
                 state.getFurnace().setOresOnConveyorBelt(Math.max(state.getFurnace().getOresOnConveyorBelt() - diff, 0));
                 if (state.getFurnace().getOresOnConveyorBelt() == 0) {
                     state.getPlayer().hasOreOnConveyor(false);
-                    log.info("hasOreOnConveyor: false");
                 }
+            }
+        }
+
+        for (int barId : bars) {
+            int diff = state.getFurnace().getChange(barId);
+            if (diff > 0) {
+                int totalBars = outputs.getOrDefault(barId, 0) + diff;
+                outputs.put(barId, totalBars);
             }
         }
     }

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/SessionStatistics.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/SessionStatistics.java
@@ -6,6 +6,7 @@ import com.toofifty.easyblastfurnace.methods.MetalBarMethod;
 import com.toofifty.easyblastfurnace.methods.Method;
 import com.toofifty.easyblastfurnace.state.BlastFurnaceState;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
@@ -19,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Singleton
+@Slf4j
 public class SessionStatistics
 {
     @Inject
@@ -169,11 +171,13 @@ public class SessionStatistics
         for (int barId : bars) {
             int diff = state.getFurnace().getChange(barId);
             if (diff > 0) {
+                log.info("Diff: " + diff + " | oresOnConveyorBelt: " + state.getFurnace().getOresOnConveyorBelt());
                 int totalBars = outputs.getOrDefault(barId, 0) + diff;
                 outputs.put(barId, totalBars);
-                state.getFurnace().setOresOnConveyorBelt(state.getFurnace().getOresOnConveyorBelt() - diff);
-                if (state.getFurnace().getOresOnConveyorBelt() <= 0) {
+                state.getFurnace().setOresOnConveyorBelt(Math.max(state.getFurnace().getOresOnConveyorBelt() - diff, 0));
+                if (state.getFurnace().getOresOnConveyorBelt() == 0) {
                     state.getPlayer().hasOreOnConveyor(false);
+                    log.info("hasOreOnConveyor: false");
                 }
             }
         }

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
@@ -18,6 +18,8 @@ public class Strings {
     public static String DEPOSIT_ENERGY_POTIONS = "Deposit Energy potions";
     public static String WITHDRAW_ICE_OR_SMITHS_GLOVES = "Withdraw ice gloves or smiths gloves (i)";
     public static String EQUIP_ICE_OR_SMITHS_GLOVES = "Equip ice gloves or smiths gloves (i)";
+    public static String COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS = "Collect bars and then immediately equip goldsmith gauntlets";
+    public static String GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES = "Go to bar dispenser and equip ice gloves or smiths gloves (i)";
     public static String WITHDRAW_GOLDSMITH_GAUNTLETS = "Withdraw goldsmith gauntlets";
     public static String EQUIP_GOLDSMITH_GAUNTLETS = "Equip goldsmith gauntlets";
     public static String WITHDRAW_SMITHING_CAPE = "Withdraw Smithing cape";

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
@@ -28,7 +28,6 @@ public class Strings {
     public static String EQUIP_MAX_CAPE = "Equip Max cape";
     public static String DEPOSIT_INVENTORY = "Deposit inventory";
     public static String PUT_ORE_ONTO_CONVEYOR_BELT = "Put ore onto conveyor belt";
-    public static String PUT_ORE_ONTO_CONVEYOR_BELT_AND_EQUIP_GOLDSMITH_GAUNTLETS = "Put ore onto conveyor belt and equip goldsmith gauntlets";
     public static String OPEN_BANK  = "Open bank chest";
     public static String COLLECT_BARS = "Collect bars";
     public static String WAIT_FOR_BARS = "Wait for bars to smelt";
@@ -47,6 +46,7 @@ public class Strings {
 
     // Patterns
     public static String COAL_FULL = "^The coal bag contains (\\d+) pieces of coal.$";
+    public static String COAL_EMPTY = "^The coal bag is now empty.$";
 
     // Actions
     public static String FILL = "Fill";

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
@@ -41,10 +41,6 @@ public class Strings {
     public static String RUNITEHYBRID = "Gold + runite bars";
     public static String STEEL = "Steel bars";
 
-    // Patterns
-    public static String COAL_FULL = "^The coal bag contains 27 pieces of coal.$";
-    public static String COAL_EMPTY = "^The coal bag is now empty.$";
-
     // Actions
     public static String FILL = "Fill";
     public static String EMPTY = "Empty";

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
@@ -18,7 +18,7 @@ public class Strings {
     public static String DEPOSIT_ENERGY_POTIONS = "Deposit Energy potions";
     public static String WITHDRAW_ICE_OR_SMITHS_GLOVES = "Withdraw ice gloves or smiths gloves (i)";
     public static String EQUIP_ICE_OR_SMITHS_GLOVES = "Equip ice gloves or smiths gloves (i)";
-    public static String COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS = "Collect bars and then immediately equip goldsmith gauntlets";
+    public static String EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS = "Equip after collecting bars";
     public static String GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES = "Go to bar dispenser and equip ice gloves or smiths gloves (i)";
     public static String WITHDRAW_GOLDSMITH_GAUNTLETS = "Withdraw goldsmith gauntlets";
     public static String EQUIP_GOLDSMITH_GAUNTLETS = "Equip goldsmith gauntlets";
@@ -28,9 +28,11 @@ public class Strings {
     public static String EQUIP_MAX_CAPE = "Equip Max cape";
     public static String DEPOSIT_INVENTORY = "Deposit inventory";
     public static String PUT_ORE_ONTO_CONVEYOR_BELT = "Put ore onto conveyor belt";
+    public static String PUT_ORE_ONTO_CONVEYOR_BELT_AND_EQUIP_GOLDSMITH_GAUNTLETS = "Put ore onto conveyor belt and equip goldsmith gauntlets";
     public static String OPEN_BANK  = "Open bank chest";
     public static String COLLECT_BARS = "Collect bars";
     public static String WAIT_FOR_BARS = "Wait for bars to smelt";
+    public static String GO_TO_DISPENSER = "Go to bar dispenser";
     public static String DRINK_STAMINA = null;
 
     // Bars
@@ -42,6 +44,9 @@ public class Strings {
     public static String RUNITE = "Runite bars";
     public static String RUNITEHYBRID = "Gold + runite bars";
     public static String STEEL = "Steel bars";
+
+    // Patterns
+    public static String COAL_FULL = "^The coal bag contains \\d+ pieces of coal.$";
 
     // Actions
     public static String FILL = "Fill";

--- a/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
+++ b/src/main/java/com/toofifty/easyblastfurnace/utils/Strings.java
@@ -46,7 +46,7 @@ public class Strings {
     public static String STEEL = "Steel bars";
 
     // Patterns
-    public static String COAL_FULL = "^The coal bag contains \\d+ pieces of coal.$";
+    public static String COAL_FULL = "^The coal bag contains (\\d+) pieces of coal.$";
 
     // Actions
     public static String FILL = "Fill";

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -5,6 +5,7 @@ import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.toofifty.easyblastfurnace.config.PotionOverlaySetting;
 import com.toofifty.easyblastfurnace.overlays.InstructionOverlay;
 import com.toofifty.easyblastfurnace.state.BlastFurnaceState;
+import com.toofifty.easyblastfurnace.steps.MethodStep;
 import com.toofifty.easyblastfurnace.utils.BarsOres;
 import com.toofifty.easyblastfurnace.utils.CoalPer;
 import com.toofifty.easyblastfurnace.utils.Strings;
@@ -681,9 +682,13 @@ public class EasyBlastFurnacePluginTest {
         easyBlastFurnacePlugin.onItemContainerChanged(event);
     }
 
-    private void assertStepTooltip(String expectedString)
+    private void assertStepTooltip(String ...expectedStrings)
     {
-        assertEquals(expectedString, methodHandler.getStep().getTooltip());
+        MethodStep[] steps = methodHandler.getSteps();
+
+        for (int i = 0; i < steps.length; i++) {
+            assertEquals(expectedStrings[i], steps[i].getTooltip());
+        }
     }
 
     private void setCoalBag(String emptyOrFillText)

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -13,10 +13,7 @@ import com.toofifty.easyblastfurnace.utils.MethodHandler;
 import com.toofifty.easyblastfurnace.utils.StaminaHelper;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
@@ -33,6 +30,7 @@ import com.google.inject.testing.fieldbinder.Bind;
 
 import javax.inject.Inject;
 
+import static net.runelite.api.ChatMessageType.GAMEMESSAGE;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -85,11 +83,12 @@ public class EasyBlastFurnacePluginTest {
     private final Widget bankWidget = mock(Widget.class);
     private final VarbitChanged blastFurnaceChange = new VarbitChanged();
     private final ItemContainerChanged event = new ItemContainerChanged(InventoryID.INVENTORY.getId(), inventoryContainer);
-    private final MenuOptionClicked menuOptionClicked = mock(MenuOptionClicked.class);
 
     private final WorldPoint atConveyorBelt = new WorldPoint(1942, 4967, 0);
     private final WorldPoint notAtConveyorBelt = new WorldPoint(1949, 4967, 0);
     private final WorldPoint atBarDispenser = new WorldPoint(1940, 4963, 0);
+    private final String coalBagEmptyMessage = "The coal bag is now empty.";
+    private final String coalBagFillMessage = "The coal bag contains 27 pieces of coal.";
 
     private int tickCount = 0;
 
@@ -244,7 +243,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(50);
         when(client.getEnergy()).thenReturn(6400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_STAMINA_POTIONS, 0);
+        assertStepTooltip(Strings.DEPOSIT_STAMINA_POTIONS);
 
         // Second deposit Inventory
         when(client.getEnergy()).thenReturn(4900);
@@ -253,7 +252,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -268,7 +267,7 @@ public class EasyBlastFurnacePluginTest {
 
         // getMoreStaminaPotions
         setBankCount(ItemID.STAMINA_POTION4, 0);
-        assertStepTooltip(Strings.GET_MORE_STAMINA_POTIONS, 0);
+        assertStepTooltip(Strings.GET_MORE_STAMINA_POTIONS);
     }
 
     @Test
@@ -290,7 +289,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(20);
         when(client.getEnergy()).thenReturn(8400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_SUPER_ENERGY_POTIONS, 0);
+        assertStepTooltip(Strings.DEPOSIT_SUPER_ENERGY_POTIONS);
 
         setInventoryItems(new Item[0]);
         // Second deposit Inventory
@@ -300,7 +299,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -319,28 +318,28 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 1);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
         setBankCount(ItemID.SUPER_ENERGY1, 0);
         setBankCount(ItemID.SUPER_ENERGY2, 1);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
         setBankCount(ItemID.SUPER_ENERGY1, 1);
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
         setBankCount(ItemID.SUPER_ENERGY1, 1);
         setBankCount(ItemID.SUPER_ENERGY2, 1);
         setBankCount(ItemID.SUPER_ENERGY3, 1);
         setBankCount(ItemID.SUPER_ENERGY4, 1);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
         // getMoreStaminaPotions
         setBankCount(ItemID.SUPER_ENERGY1, 0);
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.GET_MORE_SUPER_ENERGY_POTIONS, 0);
+        assertStepTooltip(Strings.GET_MORE_SUPER_ENERGY_POTIONS);
     }
 
     @Test
@@ -362,7 +361,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(20);
         when(client.getEnergy()).thenReturn(9400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_ENERGY_POTIONS, 0);
+        assertStepTooltip(Strings.DEPOSIT_ENERGY_POTIONS);
 
         setInventoryItems(new Item[0]);
         // Second deposit Inventory
@@ -372,7 +371,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -391,28 +390,28 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 1);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
         setBankCount(ItemID.ENERGY_POTION1, 0);
         setBankCount(ItemID.ENERGY_POTION2, 1);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
         setBankCount(ItemID.ENERGY_POTION1, 1);
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
         setBankCount(ItemID.ENERGY_POTION1, 1);
         setBankCount(ItemID.ENERGY_POTION2, 1);
         setBankCount(ItemID.ENERGY_POTION3, 1);
         setBankCount(ItemID.ENERGY_POTION4, 1);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
         // getMoreStaminaPotions
         setBankCount(ItemID.ENERGY_POTION1, 0);
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS, 0);
+        assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS);
     }
 
     private void goldSharedMethod(boolean tickPerfect)
@@ -423,42 +422,42 @@ public class EasyBlastFurnacePluginTest {
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
         setBankCount(ItemID.SMITHING_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE, 0);
+        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 1);
         setBankCount(ItemID.SMITHING_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 0);
         setBankCount(ItemID.MAX_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE, 0);
+        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
 
         setInventoryCount(ItemID.MAX_CAPE, 1);
         setBankCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_MAX_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
 
         setInventoryCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
 
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(ItemID.GOLD_ORE, 0);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
         setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
 
         setInventoryCount(ItemID.GOLD_ORE, 27);
 
@@ -474,59 +473,59 @@ public class EasyBlastFurnacePluginTest {
         setWorldPoint(atConveyorBelt);
         setInventoryCount(ItemID.GOLD_ORE, 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
 
         setWorldPoint(notAtConveyorBelt);
         setInventoryCount(ItemID.GOLD_ORE, 27);
         setWorldPoint(atConveyorBelt);
         goToAndLoadConveyorBelt(ItemID.GOLD_ORE);
-        assertStepTooltip(Strings.GO_TO_DISPENSER, 0);
+        assertStepTooltip(Strings.GO_TO_DISPENSER);
 
         setWorldPoint(notAtConveyorBelt);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
 
         setWorldPoint(atBarDispenser);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
     }
 
     private void goldNonTickPerfect()
     {
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
 
         setAtBank(false);
         equipGloves(true);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
 
         equipGloves(false);
         goToAndLoadConveyorBelt(ItemID.GOLD_ORE);
-        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setWorldPoint(atBarDispenser);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 27);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         setInventoryCount(ItemID.GOLD_BAR, 27);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
 
-        assertStepTooltip(Strings.OPEN_BANK, 0);
+        assertStepTooltip(Strings.OPEN_BANK);
 
         setAtBank(true);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(ItemID.GOLD_BAR, 0);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
         equipGloves(false);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
     }
 
     private void checkStaminaPotion(int staminaPotionA, int staminaPotionB, String methodStep)
@@ -535,7 +534,7 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(staminaPotionA, 0);
         if (methodStep.toLowerCase().contains("withdraw")) setBankCount(staminaPotionB, 1);
         else setInventoryCount(staminaPotionB, 1);
-        assertStepTooltip(methodStep, 0);
+        assertStepTooltip(methodStep);
     }
 
     private void checkStaminaHelper()
@@ -580,77 +579,77 @@ public class EasyBlastFurnacePluginTest {
         setInventoryItems(new Item[]{new Item(oreID, 1)});
         setInventoryCount(oreID, 1);
         assertEquals(methodName, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(oreID, 0);
-        assertStepTooltip(Strings.WITHDRAW_COAL_BAG, 0);
+        assertStepTooltip(Strings.WITHDRAW_COAL_BAG);
 
         setInventoryCount(ItemID.OPEN_COAL_BAG, 1);
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         setInventoryCount(ItemID.ICE_GLOVES, 0);
         setEquipmentCount(ItemID.ICE_GLOVES, 1);
 
         setInventoryCount(barID, 1);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setFurnaceCount(oreVarbit, 1);
         setFurnaceCount(barVarbit, 1);
         setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
         setInventoryCount(barID, 0);
         setInventoryCount(oreID, 1);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(oreID, 0);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 0);
         setFurnaceCount(BarsOres.COAL.getVarbit(), 0);
-        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+        assertStepTooltip(Strings.FILL_COAL_BAG);
 
-        setCoalBag(Strings.FILL);
+        setCoalBag(coalBagFillMessage);
         assertEquals(state.getCoalBag().getMaxCoal(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.WITHDRAW_COAL, 0);
+        assertStepTooltip(Strings.WITHDRAW_COAL);
 
         setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
-        assertStepTooltip(withdrawOreText, 0);
+        assertStepTooltip(withdrawOreText);
 
         setInventoryCount(oreID, 27);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
 
         goToAndLoadConveyorBelt(oreID);
-        assertStepTooltip(Strings.EMPTY_COAL_BAG, 0);
+        assertStepTooltip(Strings.EMPTY_COAL_BAG);
 
-        setCoalBag(Strings.EMPTY);
+        setCoalBag(coalBagEmptyMessage);
         assertEquals(0, state.getCoalBag().getCoal());
 
         setFurnaceCount(oreVarbit, 26);
         setFurnaceCount(barVarbit, 28);
         setInventoryCount(ItemID.COAL, 27);
-        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+        assertStepTooltip(Strings.FILL_COAL_BAG);
 
-        setCoalBag(Strings.FILL);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        setCoalBag(coalBagFillMessage);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
-        setCoalBag(Strings.EMPTY);
+        setCoalBag(coalBagEmptyMessage);
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 0);
         setInventoryCount(ItemID.COAL, 0);
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setWorldPoint(notAtConveyorBelt);
         setFurnaceCount(oreVarbit, 27);
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 27);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         collectBars(barID, barVarbit);
-        assertStepTooltip(Strings.OPEN_BANK, 0);
+        assertStepTooltip(Strings.OPEN_BANK);
     }
 
     private void hybridMethod(
@@ -661,84 +660,84 @@ public class EasyBlastFurnacePluginTest {
         setInventoryCount(oreID, 1);
         setInventoryCount(ItemID.GOLD_ORE, 1);
         assertEquals(methodName, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setAtBank(true);
         setInventoryCount(oreID, 0);
         setInventoryCount(ItemID.GOLD_ORE, 0);
-        assertStepTooltip(Strings.WITHDRAW_COAL_BAG, 0);
+        assertStepTooltip(Strings.WITHDRAW_COAL_BAG);
 
         setInventoryCount(ItemID.OPEN_COAL_BAG, 1);
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
         setBankCount(ItemID.SMITHING_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE, 0);
+        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 1);
         setBankCount(ItemID.SMITHING_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 0);
         setBankCount(ItemID.MAX_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE, 0);
+        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
 
         setInventoryCount(ItemID.MAX_CAPE, 1);
         setBankCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_MAX_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
 
         setInventoryCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
 
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 		setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
 		setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
         setInventoryCount(ItemID.GOLD_ORE, 1);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(ItemID.GOLD_ORE, 0);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
 
-		assertStepTooltip(Strings.FILL_COAL_BAG, 0);
-		setCoalBag(Strings.FILL);
+		assertStepTooltip(Strings.FILL_COAL_BAG);
+		setCoalBag(coalBagFillMessage);
 		assertEquals(state.getCoalBag().getMaxCoal(), state.getCoalBag().getCoal());
 
         setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
-		assertStepTooltip(withdrawOreText, 0);
+		assertStepTooltip(withdrawOreText);
 
         setInventoryCount(oreID, 26);
         when(easyBlastFurnaceConfig.useDepositInventory()).thenReturn(true);
-        setCoalBag(Strings.EMPTY);
-        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+        setCoalBag(coalBagEmptyMessage);
+        assertStepTooltip(Strings.FILL_COAL_BAG);
 
         when(easyBlastFurnaceConfig.useDepositInventory()).thenReturn(false);
-        setCoalBag(Strings.FILL);
+        setCoalBag(coalBagFillMessage);
         setInventoryCount(oreID, 0);
         setInventoryCount(ItemID.GOLD_ORE, 1);
         equipGloves(true);
         setAtBank(false);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
         equipGloves(false);
         setInventoryCount(ItemID.GOLD_ORE, 0);
         setInventoryCount(oreID, 26);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
 
         goToAndLoadConveyorBelt(oreID);
-        assertStepTooltip(Strings.EMPTY_COAL_BAG, 0);
-        setCoalBag(Strings.EMPTY);
+        assertStepTooltip(Strings.EMPTY_COAL_BAG);
+        setCoalBag(coalBagEmptyMessage);
 
         setFurnaceCount(barVarbit, 1);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
         setInventoryCount(ItemID.COAL, 1);
-        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+        assertStepTooltip(Strings.FILL_COAL_BAG);
 
         setFurnaceCount(barVarbit, 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
@@ -757,32 +756,32 @@ public class EasyBlastFurnacePluginTest {
     {
         setWorldPoint(atBarDispenser);
         setFurnaceCount(oreVarbit, 26);
-        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 26);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         collectBars(barID, barVarbit);
-        assertStepTooltip(Strings.OPEN_BANK, 0);
+        assertStepTooltip(Strings.OPEN_BANK);
 
         setAtBank(true);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(barID, 0);
-        assertStepTooltip(Strings.REFILL_COAL_BAG, 0);
+        assertStepTooltip(Strings.REFILL_COAL_BAG);
 
-        setCoalBag(Strings.FILL);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+        setCoalBag(coalBagFillMessage);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
         equipGloves(false);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
 
         setInventoryCount(ItemID.GOLD_ORE, 1);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
 
         setAtBank(false);
     }
@@ -794,33 +793,33 @@ public class EasyBlastFurnacePluginTest {
         setWorldPoint(atConveyorBelt);
         setInventoryCount(oreID, 0);
         setFurnaceCount(barVarbit, 1);
-        assertStepTooltip(Strings.GO_TO_DISPENSER, 0);
+        assertStepTooltip(Strings.GO_TO_DISPENSER);
 
         setWorldPoint(notAtConveyorBelt);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         setWorldPoint(atBarDispenser);
         setFurnaceCount(barVarbit, 1);
-        assertStepTooltip(Strings.COLLECT_BARS, 0);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         setFurnaceCount(barVarbit, 0);
         setFurnaceCount(BarsOres.COAL.getVarbit(), 0);
         setAtBank(true);
-        setCoalBag(Strings.FILL);
+        setCoalBag(coalBagFillMessage);
         setInventoryCount(ItemID.GOLD_ORE, 26);
         setAtBank(false);
         setWorldPoint(atConveyorBelt);
-        setCoalBag(Strings.EMPTY);
+        setCoalBag(coalBagEmptyMessage);
         setInventoryCount(ItemID.GOLD_ORE, 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
         setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
         setWorldPoint(atBarDispenser);
         equipGloves(true);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS, 0);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
 
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
         setFurnaceCount(barVarbit, 27);
-        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
     }
 
     private void collectBars(int barID, int barVarbit)
@@ -872,10 +871,10 @@ public class EasyBlastFurnacePluginTest {
         easyBlastFurnacePlugin.onItemContainerChanged(event);
     }
 
-    private void assertStepTooltip(String expectedStrings, int index)
+    private void assertStepTooltip(String expectedStrings)
     {
         MethodStep[] steps = methodHandler.getSteps();
-        assertEquals(expectedStrings, steps[index].getTooltip());
+        assertEquals(expectedStrings, steps[0].getTooltip());
 
     }
 
@@ -884,8 +883,8 @@ public class EasyBlastFurnacePluginTest {
         // Empty coal bag to get Wait for bars step
         tickCount = tickCount + 1;
         when(client.getTickCount()).thenReturn(tickCount);
-        when(menuOptionClicked.getMenuOption()).thenReturn(emptyOrFillText);
-        easyBlastFurnacePlugin.onMenuOptionClicked(menuOptionClicked);
+        ChatMessage chatMessageEvent = new ChatMessage(null, GAMEMESSAGE, "Bob", emptyOrFillText, null, 0);
+        easyBlastFurnacePlugin.onChatMessage(chatMessageEvent);
     }
 
     private void setInventoryItems(Item[] items)

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -244,7 +244,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(50);
         when(client.getEnergy()).thenReturn(6400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_STAMINA_POTIONS);
+        assertStepTooltip(Strings.DEPOSIT_STAMINA_POTIONS, 0);
 
         // Second deposit Inventory
         when(client.getEnergy()).thenReturn(4900);
@@ -253,7 +253,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -268,7 +268,7 @@ public class EasyBlastFurnacePluginTest {
 
         // getMoreStaminaPotions
         setBankCount(ItemID.STAMINA_POTION4, 0);
-        assertStepTooltip(Strings.GET_MORE_STAMINA_POTIONS);
+        assertStepTooltip(Strings.GET_MORE_STAMINA_POTIONS, 0);
     }
 
     @Test
@@ -290,7 +290,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(20);
         when(client.getEnergy()).thenReturn(8400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_SUPER_ENERGY_POTIONS);
+        assertStepTooltip(Strings.DEPOSIT_SUPER_ENERGY_POTIONS, 0);
 
         setInventoryItems(new Item[0]);
         // Second deposit Inventory
@@ -300,7 +300,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -319,28 +319,28 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 1);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
         setBankCount(ItemID.SUPER_ENERGY1, 0);
         setBankCount(ItemID.SUPER_ENERGY2, 1);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
         setBankCount(ItemID.SUPER_ENERGY1, 1);
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
         setBankCount(ItemID.SUPER_ENERGY1, 1);
         setBankCount(ItemID.SUPER_ENERGY2, 1);
         setBankCount(ItemID.SUPER_ENERGY3, 1);
         setBankCount(ItemID.SUPER_ENERGY4, 1);
-        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_SUPER_ENERGY_POTION, 0);
         // getMoreStaminaPotions
         setBankCount(ItemID.SUPER_ENERGY1, 0);
         setBankCount(ItemID.SUPER_ENERGY2, 0);
         setBankCount(ItemID.SUPER_ENERGY3, 0);
         setBankCount(ItemID.SUPER_ENERGY4, 0);
-        assertStepTooltip(Strings.GET_MORE_SUPER_ENERGY_POTIONS);
+        assertStepTooltip(Strings.GET_MORE_SUPER_ENERGY_POTIONS, 0);
     }
 
     @Test
@@ -362,7 +362,7 @@ public class EasyBlastFurnacePluginTest {
         when(easyBlastFurnaceConfig.requireStaminaThreshold()).thenReturn(20);
         when(client.getEnergy()).thenReturn(9400);
         setInventoryCount(ItemID.VIAL, 1);
-        assertStepTooltip(Strings.DEPOSIT_ENERGY_POTIONS);
+        assertStepTooltip(Strings.DEPOSIT_ENERGY_POTIONS, 0);
 
         setInventoryItems(new Item[0]);
         // Second deposit Inventory
@@ -372,7 +372,7 @@ public class EasyBlastFurnacePluginTest {
             gold[i] = new Item(ItemID.GOLD_ORE, 1);
         }
         setInventoryItems(gold);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         // drink/withdraw stamina potions
         setInventoryItems(new Item[0]);
@@ -391,71 +391,81 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 1);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
         setBankCount(ItemID.ENERGY_POTION1, 0);
         setBankCount(ItemID.ENERGY_POTION2, 1);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
         setBankCount(ItemID.ENERGY_POTION1, 1);
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
         setBankCount(ItemID.ENERGY_POTION1, 1);
         setBankCount(ItemID.ENERGY_POTION2, 1);
         setBankCount(ItemID.ENERGY_POTION3, 1);
         setBankCount(ItemID.ENERGY_POTION4, 1);
-        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION);
+        assertStepTooltip(Strings.WITHDRAW_ENERGY_POTION, 0);
         // getMoreStaminaPotions
         setBankCount(ItemID.ENERGY_POTION1, 0);
         setBankCount(ItemID.ENERGY_POTION2, 0);
         setBankCount(ItemID.ENERGY_POTION3, 0);
         setBankCount(ItemID.ENERGY_POTION4, 0);
-        assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS);
+        assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS, 0);
     }
 
     private void goldSharedMethod(boolean tickPerfect)
     {
-        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 27)});
-        setInventoryCount(ItemID.GOLD_ORE, 27);
+        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 1)});
+        setInventoryCount(ItemID.GOLD_ORE, 1);
         assertEquals(Strings.GOLD, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
+
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
         setBankCount(ItemID.SMITHING_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
+        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE, 0);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 1);
         setBankCount(ItemID.SMITHING_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
+        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE, 0);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 0);
         setBankCount(ItemID.MAX_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
+        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE, 0);
 
         setInventoryCount(ItemID.MAX_CAPE, 1);
         setBankCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
+        assertStepTooltip(Strings.EQUIP_MAX_CAPE, 0);
 
         setInventoryCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
+        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, 0);
 
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
 
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
+
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
         setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
 
-        setAtBank(false);
-        setWorldPoint(atConveyorBelt);
-        setInventoryCount(ItemID.GOLD_ORE, 0);
+        setInventoryCount(ItemID.GOLD_ORE, 27);
 
         if (tickPerfect) {
             goldTickPerfect();
         } else {
-            gold();
+            goldNonTickPerfect();
         }
     }
 
@@ -464,36 +474,59 @@ public class EasyBlastFurnacePluginTest {
         setWorldPoint(atConveyorBelt);
         setInventoryCount(ItemID.GOLD_ORE, 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
-        assertStepTooltip(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+
+        setWorldPoint(notAtConveyorBelt);
+        setInventoryCount(ItemID.GOLD_ORE, 27);
+        setWorldPoint(atConveyorBelt);
+        goToAndLoadConveyorBelt(ItemID.GOLD_ORE);
+        assertStepTooltip(Strings.GO_TO_DISPENSER, 0);
+
+        setWorldPoint(notAtConveyorBelt);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
+
 
         setWorldPoint(atBarDispenser);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS, 0);
     }
 
-    private void gold()
+    private void goldNonTickPerfect()
     {
-        assertStepTooltip(Strings.WAIT_FOR_BARS);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+
+        setAtBank(false);
+        equipGloves(true);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+
+
+        equipGloves(false);
+        goToAndLoadConveyorBelt(ItemID.GOLD_ORE);
+        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
 
         setWorldPoint(atBarDispenser);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 27);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
 
         equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
 
         setInventoryCount(ItemID.GOLD_BAR, 27);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
 
-        assertStepTooltip(Strings.OPEN_BANK);
+        assertStepTooltip(Strings.OPEN_BANK, 0);
 
         setAtBank(true);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         setInventoryCount(ItemID.GOLD_BAR, 0);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
 
         equipGloves(false);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
     }
 
     private void checkStaminaPotion(int staminaPotionA, int staminaPotionB, String methodStep)
@@ -502,7 +535,7 @@ public class EasyBlastFurnacePluginTest {
         setBankCount(staminaPotionA, 0);
         if (methodStep.toLowerCase().contains("withdraw")) setBankCount(staminaPotionB, 1);
         else setInventoryCount(staminaPotionB, 1);
-        assertStepTooltip(methodStep);
+        assertStepTooltip(methodStep, 0);
     }
 
     private void checkStaminaHelper()
@@ -547,46 +580,77 @@ public class EasyBlastFurnacePluginTest {
         setInventoryItems(new Item[]{new Item(oreID, 1)});
         setInventoryCount(oreID, 1);
         assertEquals(methodName, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.WITHDRAW_COAL_BAG);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+
+        setInventoryCount(oreID, 0);
+        assertStepTooltip(Strings.WITHDRAW_COAL_BAG, 0);
 
         setInventoryCount(ItemID.OPEN_COAL_BAG, 1);
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
 
         setInventoryCount(ItemID.ICE_GLOVES, 0);
         setEquipmentCount(ItemID.ICE_GLOVES, 1);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+
+        setInventoryCount(barID, 1);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+
+        setFurnaceCount(oreVarbit, 1);
+        setFurnaceCount(barVarbit, 1);
+        setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
+        setInventoryCount(barID, 0);
+        setInventoryCount(oreID, 1);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         setInventoryCount(oreID, 0);
-        assertStepTooltip(Strings.FILL_COAL_BAG);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
+
+        setFurnaceCount(oreVarbit, 0);
+        setFurnaceCount(barVarbit, 0);
+        setFurnaceCount(BarsOres.COAL.getVarbit(), 0);
+        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
 
         setCoalBag(Strings.FILL);
         assertEquals(state.getCoalBag().getMaxCoal(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.WITHDRAW_COAL);
+        assertStepTooltip(Strings.WITHDRAW_COAL, 0);
 
         setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
-        assertStepTooltip(withdrawOreText);
+        assertStepTooltip(withdrawOreText, 0);
 
-        setInventoryCount(oreID, 1);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
+        setInventoryCount(oreID, 27);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
 
-        goToAndLoadFurnace(oreID, oreVarbit);
-        assertStepTooltip(Strings.EMPTY_COAL_BAG);
+        goToAndLoadConveyorBelt(oreID);
+        assertStepTooltip(Strings.EMPTY_COAL_BAG, 0);
 
         setCoalBag(Strings.EMPTY);
         assertEquals(0, state.getCoalBag().getCoal());
+
+        setFurnaceCount(oreVarbit, 26);
+        setFurnaceCount(barVarbit, 28);
+        setInventoryCount(ItemID.COAL, 27);
+        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+
+        setCoalBag(Strings.FILL);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
+
+        setCoalBag(Strings.EMPTY);
+        setFurnaceCount(oreVarbit, 0);
+        setFurnaceCount(barVarbit, 0);
+        setInventoryCount(ItemID.COAL, 0);
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.WAIT_FOR_BARS);
+        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
 
         setWorldPoint(notAtConveyorBelt);
+        setFurnaceCount(oreVarbit, 27);
         setFurnaceCount(oreVarbit, 0);
-        setFurnaceCount(barVarbit, 1);
-        assertStepTooltip(Strings.COLLECT_BARS);
+        setFurnaceCount(barVarbit, 27);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
 
         collectBars(barID, barVarbit);
-        assertStepTooltip(Strings.OPEN_BANK);
+        assertStepTooltip(Strings.OPEN_BANK, 0);
     }
 
     private void hybridMethod(
@@ -597,94 +661,130 @@ public class EasyBlastFurnacePluginTest {
         setInventoryCount(oreID, 1);
         setInventoryCount(ItemID.GOLD_ORE, 1);
         assertEquals(methodName, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.WITHDRAW_COAL_BAG);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
+        setAtBank(true);
+        setInventoryCount(oreID, 0);
         setInventoryCount(ItemID.GOLD_ORE, 0);
+        assertStepTooltip(Strings.WITHDRAW_COAL_BAG, 0);
+
         setInventoryCount(ItemID.OPEN_COAL_BAG, 1);
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES, 0);
 
         setInventoryCount(ItemID.ICE_GLOVES, 1);
         setBankCount(ItemID.SMITHING_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
+        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE, 0);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 1);
         setBankCount(ItemID.SMITHING_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
+        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE, 0);
 
         setInventoryCount(ItemID.SMITHING_CAPE, 0);
         setBankCount(ItemID.MAX_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
+        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE, 0);
 
         setInventoryCount(ItemID.MAX_CAPE, 1);
         setBankCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
+        assertStepTooltip(Strings.EQUIP_MAX_CAPE, 0);
 
         setInventoryCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
+        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS, 0);
 
         setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
 		setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
 		setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
 
-		setInventoryCount(oreID, 0);
-		assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
+        setInventoryCount(ItemID.GOLD_ORE, 1);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
-		setInventoryCount(oreID, 1);
-		assertStepTooltip(Strings.FILL_COAL_BAG);
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
+
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
+
+		assertStepTooltip(Strings.FILL_COAL_BAG, 0);
 		setCoalBag(Strings.FILL);
 		assertEquals(state.getCoalBag().getMaxCoal(), state.getCoalBag().getCoal());
 
         setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
-		setInventoryCount(oreID, 0);
-		assertStepTooltip(withdrawOreText);
+		assertStepTooltip(withdrawOreText, 0);
 
-        setInventoryCount(oreID, 1);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
-
-        goToAndLoadFurnace(oreID, oreVarbit);
-        assertStepTooltip(Strings.EMPTY_COAL_BAG);
-
+        setInventoryCount(oreID, 26);
+        when(easyBlastFurnaceConfig.useDepositInventory()).thenReturn(true);
         setCoalBag(Strings.EMPTY);
+        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+
+        when(easyBlastFurnaceConfig.useDepositInventory()).thenReturn(false);
+        setCoalBag(Strings.FILL);
+        setInventoryCount(oreID, 0);
+        setInventoryCount(ItemID.GOLD_ORE, 1);
+        equipGloves(true);
+        setAtBank(false);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+
+        equipGloves(false);
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        setInventoryCount(oreID, 26);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
+
+        goToAndLoadConveyorBelt(oreID);
+        assertStepTooltip(Strings.EMPTY_COAL_BAG, 0);
+        setCoalBag(Strings.EMPTY);
+
+        setFurnaceCount(barVarbit, 1);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
+        setInventoryCount(ItemID.COAL, 1);
+        assertStepTooltip(Strings.FILL_COAL_BAG, 0);
+
+        setFurnaceCount(barVarbit, 0);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+        setInventoryCount(ItemID.COAL, 0);
         assertEquals(1, state.getCoalBag().getCoal());
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
 
         if (tickPerfect) {
             hybridTickPerfect(oreID, barVarbit, coalPer);
         } else {
-            hybrid(oreVarbit, barID, barVarbit);
+            hybridNonTickPerfect(oreVarbit, barID, barVarbit);
         }
     }
 
-    private void hybrid(int oreVarbit, int barID, int barVarbit)
+    private void hybridNonTickPerfect(int oreVarbit, int barID, int barVarbit)
     {
-        assertStepTooltip(Strings.WAIT_FOR_BARS);
-
         setWorldPoint(atBarDispenser);
+        setFurnaceCount(oreVarbit, 26);
+        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
+
         setFurnaceCount(oreVarbit, 0);
-        setFurnaceCount(barVarbit, 2);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+        setFurnaceCount(barVarbit, 26);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
 
         equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
 
         collectBars(barID, barVarbit);
-        assertStepTooltip(Strings.OPEN_BANK);
+        assertStepTooltip(Strings.OPEN_BANK, 0);
 
         setAtBank(true);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES, 0);
 
         setInventoryCount(barID, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
-
-        setInventoryCount(ItemID.GOLD_ORE, 1);
-        assertStepTooltip(Strings.REFILL_COAL_BAG);
+        assertStepTooltip(Strings.REFILL_COAL_BAG, 0);
 
         setCoalBag(Strings.FILL);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS, 0);
+
+        equipGloves(false);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE, 0);
+
+        setInventoryCount(ItemID.GOLD_ORE, 1);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT, 0);
 
         setAtBank(false);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
     }
 
     private void hybridTickPerfect(int oreID, int barVarbit, int coalPer)
@@ -694,11 +794,33 @@ public class EasyBlastFurnacePluginTest {
         setWorldPoint(atConveyorBelt);
         setInventoryCount(oreID, 0);
         setFurnaceCount(barVarbit, 1);
-        assertStepTooltip(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(Strings.GO_TO_DISPENSER, 0);
+
+        setWorldPoint(notAtConveyorBelt);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES, 0);
 
         setWorldPoint(atBarDispenser);
         setFurnaceCount(barVarbit, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
+        assertStepTooltip(Strings.COLLECT_BARS, 0);
+
+        setFurnaceCount(barVarbit, 0);
+        setFurnaceCount(BarsOres.COAL.getVarbit(), 0);
+        setAtBank(true);
+        setCoalBag(Strings.FILL);
+        setInventoryCount(ItemID.GOLD_ORE, 26);
+        setAtBank(false);
+        setWorldPoint(atConveyorBelt);
+        setCoalBag(Strings.EMPTY);
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 28);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 26);
+        setWorldPoint(atBarDispenser);
+        equipGloves(true);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS, 0);
+
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+        setFurnaceCount(barVarbit, 27);
+        assertStepTooltip(Strings.WAIT_FOR_BARS, 0);
     }
 
     private void collectBars(int barID, int barVarbit)
@@ -708,12 +830,11 @@ public class EasyBlastFurnacePluginTest {
         setFurnaceCount(barVarbit, 0);
     }
 
-    private void goToAndLoadFurnace(int oreID, int oreVarbit)
+    private void goToAndLoadConveyorBelt(int oreID)
     {
         setAtBank(false);
         setWorldPoint(atConveyorBelt);
         setInventoryCount(oreID, 0);
-        setFurnaceCount(oreVarbit, 1);
     }
 
     private void setInventoryCount(int itemID, int count)
@@ -751,10 +872,10 @@ public class EasyBlastFurnacePluginTest {
         easyBlastFurnacePlugin.onItemContainerChanged(event);
     }
 
-    private void assertStepTooltip(String expectedStrings)
+    private void assertStepTooltip(String expectedStrings, int index)
     {
         MethodStep[] steps = methodHandler.getSteps();
-        assertEquals(expectedStrings, steps[steps.length - 1].getTooltip());
+        assertEquals(expectedStrings, steps[index].getTooltip());
 
     }
 

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -89,6 +89,7 @@ public class EasyBlastFurnacePluginTest {
 
     private final WorldPoint atConveyorBelt = new WorldPoint(1942, 4967, 0);
     private final WorldPoint notAtConveyorBelt = new WorldPoint(1949, 4967, 0);
+    private final WorldPoint atBarDispenser = new WorldPoint(1940, 4963, 0);
 
     private int tickCount = 0;
 
@@ -173,7 +174,10 @@ public class EasyBlastFurnacePluginTest {
             ItemID.MITHRIL_ORE, BarsOres.MITHRIL_ORE.getVarbit(),
             ItemID.MITHRIL_BAR, BarsOres.MITHRIL_BAR.getVarbit(),
             Strings.WITHDRAW_MITHRIL_ORE, Strings.MITHRILHYBRID,
-            CoalPer.MITHRIL.getValue()
+            CoalPer.MITHRIL.getValue(),
+            Strings.WAIT_FOR_BARS,
+            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
+            Strings.COLLECT_BARS
         );
     }
 
@@ -184,7 +188,10 @@ public class EasyBlastFurnacePluginTest {
             ItemID.ADAMANTITE_ORE, BarsOres.ADAMANTITE_ORE.getVarbit(),
             ItemID.ADAMANTITE_BAR, BarsOres.ADAMANTITE_BAR.getVarbit(),
             Strings.WITHDRAW_ADAMANTITE_ORE, Strings.ADAMANTITEHYBRID,
-            CoalPer.ADAMANTITE.getValue()
+            CoalPer.ADAMANTITE.getValue(),
+            Strings.WAIT_FOR_BARS,
+            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
+            Strings.COLLECT_BARS
         );
     }
 
@@ -195,71 +202,49 @@ public class EasyBlastFurnacePluginTest {
             ItemID.RUNITE_ORE, BarsOres.RUNITE_ORE.getVarbit(),
             ItemID.RUNITE_BAR, BarsOres.RUNITE_BAR.getVarbit(),
             Strings.WITHDRAW_RUNITE_ORE, Strings.RUNITEHYBRID,
-            CoalPer.RUNITE.getValue()
+            CoalPer.RUNITE.getValue(),
+            Strings.WAIT_FOR_BARS,
+            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
+            Strings.COLLECT_BARS
+        );
+    }
+
+    @Test
+    public void runiteHybridTickPerfectMethod()
+    {
+        when(easyBlastFurnaceConfig.tickPerfectMethod()).thenReturn(true);
+        hybridMethod(
+            ItemID.RUNITE_ORE, BarsOres.RUNITE_ORE.getVarbit(),
+            ItemID.RUNITE_BAR, BarsOres.RUNITE_BAR.getVarbit(),
+            Strings.WITHDRAW_RUNITE_ORE, Strings.RUNITEHYBRID,
+            CoalPer.RUNITE.getValue(),
+            Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES,
+            Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
+            Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS
         );
     }
 
     @Test
     public void goldBarMethod()
     {
-        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 1)});
-        setInventoryCount(ItemID.GOLD_ORE, 1);
-        assertEquals(Strings.GOLD, methodHandler.getMethod().getName());
-        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
+        goldMethod(
+                Strings.WAIT_FOR_BARS,
+                Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
+                Strings.COLLECT_BARS,
+                Strings.EQUIP_GOLDSMITH_GAUNTLETS
+        );
+    }
 
-        setInventoryCount(ItemID.ICE_GLOVES, 1);
-        setBankCount(ItemID.SMITHING_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
-
-        setInventoryCount(ItemID.SMITHING_CAPE, 1);
-        setBankCount(ItemID.SMITHING_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
-
-        setInventoryCount(ItemID.SMITHING_CAPE, 0);
-        setBankCount(ItemID.MAX_CAPE, 1);
-        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
-
-        setInventoryCount(ItemID.MAX_CAPE, 1);
-        setBankCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
-
-        setInventoryCount(ItemID.MAX_CAPE, 0);
-        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
-
-        setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
-
-        setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
-        setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
-        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
-
-        setAtBank(false);
-        setWorldPoint(atConveyorBelt);
-        setInventoryCount(ItemID.GOLD_ORE, 0);
-        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 1);
-        assertStepTooltip(Strings.WAIT_FOR_BARS);
-
-        setWorldPoint(notAtConveyorBelt);
-        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
-        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
-
-        equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS);
-
-        setWorldPoint(notAtConveyorBelt);
-        setInventoryCount(ItemID.GOLD_BAR, 1);
-        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
-        assertStepTooltip(Strings.OPEN_BANK);
-
-        setAtBank(true);
-        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
-
-        setInventoryCount(ItemID.GOLD_BAR, 0);
-        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
-
-        equipGloves(false);
-        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
+    @Test
+    public void goldBarTickPerfectMethod()
+    {
+        when(easyBlastFurnaceConfig.tickPerfectMethod()).thenReturn(true);
+        goldMethod(
+                Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES,
+                Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
+                Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
+                Strings.WITHDRAW_GOLD_ORE
+        );
     }
 
     @Test
@@ -452,6 +437,67 @@ public class EasyBlastFurnacePluginTest {
         assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS);
     }
 
+    private void goldMethod(String barStep, String equipIceGlovesStep, String collectBarsStep, String equipGoldsmithGauntlets)
+    {
+        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 1)});
+        setInventoryCount(ItemID.GOLD_ORE, 1);
+        assertEquals(Strings.GOLD, methodHandler.getMethod().getName());
+        assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
+
+        setInventoryCount(ItemID.ICE_GLOVES, 1);
+        setBankCount(ItemID.SMITHING_CAPE, 1);
+        assertStepTooltip(Strings.WITHDRAW_SMITHING_CAPE);
+
+        setInventoryCount(ItemID.SMITHING_CAPE, 1);
+        setBankCount(ItemID.SMITHING_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_SMITHING_CAPE);
+
+        setInventoryCount(ItemID.SMITHING_CAPE, 0);
+        setBankCount(ItemID.MAX_CAPE, 1);
+        assertStepTooltip(Strings.WITHDRAW_MAX_CAPE);
+
+        setInventoryCount(ItemID.MAX_CAPE, 1);
+        setBankCount(ItemID.MAX_CAPE, 0);
+        assertStepTooltip(Strings.EQUIP_MAX_CAPE);
+
+        setInventoryCount(ItemID.MAX_CAPE, 0);
+        assertStepTooltip(Strings.WITHDRAW_GOLDSMITH_GAUNTLETS);
+
+        setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+
+        setInventoryCount(ItemID.GOLDSMITH_GAUNTLETS, 0);
+        setEquipmentCount(ItemID.GOLDSMITH_GAUNTLETS, 1);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
+
+        setAtBank(false);
+        setWorldPoint(atConveyorBelt);
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 1);
+        assertStepTooltip(barStep);
+
+        setWorldPoint(atBarDispenser);
+        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
+        assertStepTooltip(equipIceGlovesStep);
+
+        equipGloves(true);
+        assertStepTooltip(collectBarsStep);
+
+        setInventoryCount(ItemID.GOLD_BAR, 1);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
+
+        assertStepTooltip(Strings.OPEN_BANK);
+
+        setAtBank(true);
+        assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
+
+        setInventoryCount(ItemID.GOLD_BAR, 0);
+        assertStepTooltip(equipGoldsmithGauntlets);
+
+        equipGloves(false);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
+    }
 
     private void checkStaminaPotion(int staminaPotionA, int staminaPotionB, String methodStep)
     {
@@ -547,7 +593,8 @@ public class EasyBlastFurnacePluginTest {
     }
 
     private void hybridMethod(
-        int oreID, int oreVarbit, int barID, int barVarbit, String withdrawOreText, String methodName, int coalPer
+        int oreID, int oreVarbit, int barID, int barVarbit, String withdrawOreText, String methodName, int coalPer,
+        String waitForBars, String equipIceGloves, String collectBars
     ) {
         setInventoryItems(new Item[]{ new Item(ItemID.OPEN_COAL_BAG, 1), new Item(oreID, 1) });
         setInventoryCount(oreID, 1);
@@ -604,15 +651,15 @@ public class EasyBlastFurnacePluginTest {
         setCoalBag(Strings.EMPTY);
         assertEquals(1, state.getCoalBag().getCoal());
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
-        assertStepTooltip(Strings.WAIT_FOR_BARS);
+        assertStepTooltip(waitForBars);
 
-        setWorldPoint(notAtConveyorBelt);
+        setWorldPoint(atBarDispenser);
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 2);
-        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
+        assertStepTooltip(equipIceGloves);
 
         equipGloves(true);
-        assertStepTooltip(Strings.COLLECT_BARS);
+        assertStepTooltip(collectBars);
 
         collectBars(barID, barVarbit);
         assertStepTooltip(Strings.OPEN_BANK);
@@ -684,13 +731,11 @@ public class EasyBlastFurnacePluginTest {
         easyBlastFurnacePlugin.onItemContainerChanged(event);
     }
 
-    private void assertStepTooltip(String ...expectedStrings)
+    private void assertStepTooltip(String expectedStrings)
     {
         MethodStep[] steps = methodHandler.getSteps();
+        assertEquals(expectedStrings, steps[steps.length - 1].getTooltip());
 
-        for (int i = 0; i < steps.length; i++) {
-            assertEquals(expectedStrings[i], steps[i].getTooltip());
-        }
     }
 
     private void setCoalBag(String emptyOrFillText)

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -549,7 +549,7 @@ public class EasyBlastFurnacePluginTest {
     private void hybridMethod(
         int oreID, int oreVarbit, int barID, int barVarbit, String withdrawOreText, String methodName, int coalPer
     ) {
-        setInventoryItems(new Item[]{new Item(oreID, 1), new Item(ItemID.GOLD_ORE, 1)});
+        setInventoryItems(new Item[]{ new Item(ItemID.OPEN_COAL_BAG, 1), new Item(oreID, 1) });
         setInventoryCount(oreID, 1);
         setInventoryCount(ItemID.GOLD_ORE, 1);
         assertEquals(methodName, methodHandler.getMethod().getName());

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -174,10 +174,7 @@ public class EasyBlastFurnacePluginTest {
             ItemID.MITHRIL_ORE, BarsOres.MITHRIL_ORE.getVarbit(),
             ItemID.MITHRIL_BAR, BarsOres.MITHRIL_BAR.getVarbit(),
             Strings.WITHDRAW_MITHRIL_ORE, Strings.MITHRILHYBRID,
-            CoalPer.MITHRIL.getValue(),
-            Strings.WAIT_FOR_BARS,
-            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
-            Strings.COLLECT_BARS
+            CoalPer.MITHRIL.getValue(), false
         );
     }
 
@@ -188,10 +185,7 @@ public class EasyBlastFurnacePluginTest {
             ItemID.ADAMANTITE_ORE, BarsOres.ADAMANTITE_ORE.getVarbit(),
             ItemID.ADAMANTITE_BAR, BarsOres.ADAMANTITE_BAR.getVarbit(),
             Strings.WITHDRAW_ADAMANTITE_ORE, Strings.ADAMANTITEHYBRID,
-            CoalPer.ADAMANTITE.getValue(),
-            Strings.WAIT_FOR_BARS,
-            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
-            Strings.COLLECT_BARS
+            CoalPer.ADAMANTITE.getValue(), false
         );
     }
 
@@ -202,10 +196,7 @@ public class EasyBlastFurnacePluginTest {
             ItemID.RUNITE_ORE, BarsOres.RUNITE_ORE.getVarbit(),
             ItemID.RUNITE_BAR, BarsOres.RUNITE_BAR.getVarbit(),
             Strings.WITHDRAW_RUNITE_ORE, Strings.RUNITEHYBRID,
-            CoalPer.RUNITE.getValue(),
-            Strings.WAIT_FOR_BARS,
-            Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
-            Strings.COLLECT_BARS
+            CoalPer.RUNITE.getValue(), false
         );
     }
 
@@ -217,34 +208,21 @@ public class EasyBlastFurnacePluginTest {
             ItemID.RUNITE_ORE, BarsOres.RUNITE_ORE.getVarbit(),
             ItemID.RUNITE_BAR, BarsOres.RUNITE_BAR.getVarbit(),
             Strings.WITHDRAW_RUNITE_ORE, Strings.RUNITEHYBRID,
-            CoalPer.RUNITE.getValue(),
-            Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES,
-            Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
-            Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS
+            CoalPer.RUNITE.getValue(), true
         );
     }
 
     @Test
     public void goldBarMethod()
     {
-        goldMethod(
-                Strings.WAIT_FOR_BARS,
-                Strings.EQUIP_ICE_OR_SMITHS_GLOVES,
-                Strings.COLLECT_BARS,
-                Strings.EQUIP_GOLDSMITH_GAUNTLETS
-        );
+        goldSharedMethod(false);
     }
 
     @Test
     public void goldBarTickPerfectMethod()
     {
         when(easyBlastFurnaceConfig.tickPerfectMethod()).thenReturn(true);
-        goldMethod(
-                Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES,
-                Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
-                Strings.COLLECT_BARS_AND_EQUIP_GOLDSMITH_GAUNTLETS,
-                Strings.WITHDRAW_GOLD_ORE
-        );
+        goldSharedMethod(true);
     }
 
     @Test
@@ -437,10 +415,10 @@ public class EasyBlastFurnacePluginTest {
         assertStepTooltip(Strings.GET_MORE_ENERGY_POTIONS);
     }
 
-    private void goldMethod(String barStep, String equipIceGlovesStep, String collectBarsStep, String equipGoldsmithGauntlets)
+    private void goldSharedMethod(boolean tickPerfect)
     {
-        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 1)});
-        setInventoryCount(ItemID.GOLD_ORE, 1);
+        setInventoryItems(new Item[]{new Item(ItemID.GOLD_ORE, 27)});
+        setInventoryCount(ItemID.GOLD_ORE, 27);
         assertEquals(Strings.GOLD, methodHandler.getMethod().getName());
         assertStepTooltip(Strings.WITHDRAW_ICE_OR_SMITHS_GLOVES);
 
@@ -473,18 +451,37 @@ public class EasyBlastFurnacePluginTest {
         setAtBank(false);
         setWorldPoint(atConveyorBelt);
         setInventoryCount(ItemID.GOLD_ORE, 0);
-        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 1);
-        assertStepTooltip(barStep);
+
+        if (tickPerfect) {
+            goldTickPerfect();
+        } else {
+            gold();
+        }
+    }
+
+    private void goldTickPerfect()
+    {
+        setWorldPoint(atConveyorBelt);
+        setInventoryCount(ItemID.GOLD_ORE, 0);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
+        assertStepTooltip(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES);
 
         setWorldPoint(atBarDispenser);
-        setFurnaceCount(BarsOres.GOLD_ORE.getVarbit(), 0);
-        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 1);
-        assertStepTooltip(equipIceGlovesStep);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
+    }
+
+    private void gold()
+    {
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
+
+        setWorldPoint(atBarDispenser);
+        setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 27);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         equipGloves(true);
-        assertStepTooltip(collectBarsStep);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
-        setInventoryCount(ItemID.GOLD_BAR, 1);
+        setInventoryCount(ItemID.GOLD_BAR, 27);
         setFurnaceCount(BarsOres.GOLD_BAR.getVarbit(), 0);
 
         assertStepTooltip(Strings.OPEN_BANK);
@@ -493,7 +490,7 @@ public class EasyBlastFurnacePluginTest {
         assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(ItemID.GOLD_BAR, 0);
-        assertStepTooltip(equipGoldsmithGauntlets);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
 
         equipGloves(false);
         assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
@@ -594,7 +591,7 @@ public class EasyBlastFurnacePluginTest {
 
     private void hybridMethod(
         int oreID, int oreVarbit, int barID, int barVarbit, String withdrawOreText, String methodName, int coalPer,
-        String waitForBars, String equipIceGloves, String collectBars
+        boolean tickPerfect
     ) {
         setInventoryItems(new Item[]{ new Item(ItemID.OPEN_COAL_BAG, 1), new Item(oreID, 1) });
         setInventoryCount(oreID, 1);
@@ -651,15 +648,25 @@ public class EasyBlastFurnacePluginTest {
         setCoalBag(Strings.EMPTY);
         assertEquals(1, state.getCoalBag().getCoal());
         setFurnaceCount(BarsOres.COAL.getVarbit(), state.getCoalBag().getCoal());
-        assertStepTooltip(waitForBars);
+
+        if (tickPerfect) {
+            hybridTickPerfect(oreID, barVarbit, coalPer);
+        } else {
+            hybrid(oreVarbit, barID, barVarbit);
+        }
+    }
+
+    private void hybrid(int oreVarbit, int barID, int barVarbit)
+    {
+        assertStepTooltip(Strings.WAIT_FOR_BARS);
 
         setWorldPoint(atBarDispenser);
         setFurnaceCount(oreVarbit, 0);
         setFurnaceCount(barVarbit, 2);
-        assertStepTooltip(equipIceGloves);
+        assertStepTooltip(Strings.EQUIP_ICE_OR_SMITHS_GLOVES);
 
         equipGloves(true);
-        assertStepTooltip(collectBars);
+        assertStepTooltip(Strings.COLLECT_BARS);
 
         collectBars(barID, barVarbit);
         assertStepTooltip(Strings.OPEN_BANK);
@@ -668,17 +675,30 @@ public class EasyBlastFurnacePluginTest {
         assertStepTooltip(Strings.DEPOSIT_BARS_AND_ORES);
 
         setInventoryCount(barID, 0);
-		assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
+        assertStepTooltip(Strings.WITHDRAW_GOLD_ORE);
 
-		setInventoryCount(ItemID.GOLD_ORE, 1);
-		assertStepTooltip(Strings.REFILL_COAL_BAG);
+        setInventoryCount(ItemID.GOLD_ORE, 1);
+        assertStepTooltip(Strings.REFILL_COAL_BAG);
 
-		setCoalBag(Strings.FILL);
-		assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
+        setCoalBag(Strings.FILL);
+        assertStepTooltip(Strings.PUT_ORE_ONTO_CONVEYOR_BELT);
 
-		setAtBank(false);
-		assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+        setAtBank(false);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS);
+    }
 
+    private void hybridTickPerfect(int oreID, int barVarbit, int coalPer)
+    {
+        setFurnaceCount(BarsOres.COAL.getVarbit(), 27 * (coalPer - state.getFurnace().getCoalOffset()));
+        setInventoryCount(oreID, 1);
+        setWorldPoint(atConveyorBelt);
+        setInventoryCount(oreID, 0);
+        setFurnaceCount(barVarbit, 1);
+        assertStepTooltip(Strings.GO_TO_DISPENSER_AND_EQUIP_ICE_OR_SMITHS_GLOVES);
+
+        setWorldPoint(atBarDispenser);
+        setFurnaceCount(barVarbit, 1);
+        assertStepTooltip(Strings.EQUIP_GOLDSMITH_GAUNTLETS_AFTER_COLLECT_BARS);
     }
 
     private void collectBars(int barID, int barVarbit)

--- a/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
+++ b/src/test/java/com/toofifty/easyblastfurnace/EasyBlastFurnacePluginTest.java
@@ -90,6 +90,8 @@ public class EasyBlastFurnacePluginTest {
     private final WorldPoint atConveyorBelt = new WorldPoint(1942, 4967, 0);
     private final WorldPoint notAtConveyorBelt = new WorldPoint(1949, 4967, 0);
 
+    private int tickCount = 0;
+
     @Before
     public void before()
     {
@@ -694,6 +696,8 @@ public class EasyBlastFurnacePluginTest {
     private void setCoalBag(String emptyOrFillText)
     {
         // Empty coal bag to get Wait for bars step
+        tickCount = tickCount + 1;
+        when(client.getTickCount()).thenReturn(tickCount);
         when(menuOptionClicked.getMenuOption()).thenReturn(emptyOrFillText);
         easyBlastFurnacePlugin.onMenuOptionClicked(menuOptionClicked);
     }


### PR DESCRIPTION
- Added Tick-perfect methods as a config option that includes a proper tick-perfect gold bar method as well as improved gold-hybrid / metal methods. The Tick Perfect Gold method is a little tricky to get the hang of, but this plugin certainly helps!

- Allowed adding multiple highlights to objects and items at the same time, and utilised this new feature where appropriate.

- Made improvements to the coal bag counter: 
  - Clicking Empty on the coal bag more than once during a tick now reduces the displayed number of coal by the expected amount.
  - The correct coal count will now be displayed when partially filling the coal bag.

- Added measures to prevent trying to add more ore to the furnace when it's full and can't take any more ore.



